### PR TITLE
ESCP-2429: Add metadata call to RIO API

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/Metadata.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Metadata.kt
@@ -1,0 +1,9 @@
+package com.spectralogic.rioclient
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+
+data class ListMetadataValuesDistinct(@JsonProperty("results") override val objects: List<Map<String, String>>, override val page: PageInfo) : PageData<Map<String, String>>
+
+

--- a/src/main/kotlin/com/spectralogic/rioclient/Metadata.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Metadata.kt
@@ -1,8 +1,6 @@
 package com.spectralogic.rioclient
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import io.ktor.client.request.get
-import io.ktor.client.request.header
 
 data class ListMetadataValuesDistinct(@JsonProperty("results") override val objects: List<Map<String, String>>, override val page: PageInfo) : PageData<Map<String, String>>
 

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -547,4 +547,10 @@ class RioClient(rioUrl: URL, val username: String = "spectra", val password: Str
             t.response.status.value == HttpStatusCode.OK.value
         }
     }
+
+    suspend fun metadataValues(brokerName: String, metadataKey: String, page: Long = 0, perPage: Long = 100, internal: Boolean): ListMetadataValuesDistinct {
+        return client.get("$api/brokers/$brokerName/metadata/$metadataKey?page=$page&per_page=$perPage&internalData=$internal") {
+            header("Authorization", "Bearer ${tokenCreateContainer.token}")
+        }
+    }
 }


### PR DESCRIPTION
To be compatible with Rio Cruise we need to be able to query Metadata.
This PR adds one datastructure and one call to the client.