### PR TITLE
Bug fix for exception mapping to message object

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -56,7 +56,7 @@ class RioHttpException(
                 RioValidationErrorMessage::class.java,
                 RioUnsupportedMediaError::class.java,
                 RioDownstreamErrorMessage::class.java,
-                RioResourceErrorMessage::class.java
+                RioDefaultErrorMessage::class.java
             ).forEach {
                 try {
                     return mapper.readValue(errorResponse, it)


### PR DESCRIPTION
After a lot of head banging, I see that I doubled up one and missed one of the message object classes.