### PR TITLE
Fix list responses

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -22,6 +22,12 @@ data class BrokerResponse(
     val objectCount: Long
 ) : RioResponse()
 
+data class BrokerData(
+    val name: String,
+    val creationDate: String,
+    val objectCount: Long
+)
+
 sealed class AgentConfig
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -117,6 +123,16 @@ data class AgentResponse(
     val indexState: String?
 ) : RioResponse()
 
+data class AgentData(
+    val name: String,
+    val type: String,
+    val creationDate: String,
+    val lastIndexDate: String?,
+    val writable: Boolean,
+    val agentConfig: Map<String, String>,
+    val indexState: String?
+)
+
 data class ObjectResponse(
     val name: String,
     val size: Long,
@@ -126,6 +142,16 @@ data class ObjectResponse(
     val metadata: Map<String, String>,
     val internalMetadata: Map<String, String>? = null
 ) : RioResponse()
+
+data class ObjectData(
+    val name: String,
+    val size: Long,
+    val creationDate: String,
+    val broker: String,
+    val checksum: Checksum,
+    val metadata: Map<String, String>,
+    val internalMetadata: Map<String, String>? = null
+)
 
 data class ObjectBatchUpdateRequest(
     val objects: List<ObjectUpdateRequest>
@@ -139,16 +165,16 @@ data class ObjectUpdateRequest(
 data class Checksum(val hash: String, val type: String)
 
 data class ObjectListResponse(
-    val objects: List<ObjectResponse>,
+    val objects: List<ObjectData>,
     val page: PageInfo
 ) : RioResponse()
 
 data class BrokerListResponse(
-    @JsonProperty("brokers") val objects: List<BrokerResponse>,
+    @JsonProperty("brokers") val objects: List<BrokerData>,
     val page: PageInfo
 ) : RioResponse()
 
 data class AgentListResponse(
-    @JsonProperty("agents") val objects: List<AgentResponse>,
+    @JsonProperty("agents") val objects: List<AgentData>,
     val page: PageInfo
 ) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
@@ -10,7 +10,7 @@ data class ClusterResponse(
 ) : RioResponse()
 
 data class ClusterMembersListResponse(
-    val clusterMembers: List<ClusterMemberResponse>
+    val clusterMembers: List<ClusterMemberData>
 ) : RioResponse()
 
 data class ClusterMemberResponse(
@@ -20,3 +20,11 @@ data class ClusterMemberResponse(
     val httpPort: Int,
     val role: String
 ) : RioResponse()
+
+data class ClusterMemberData(
+    val memberId: String,
+    val ipAddress: String,
+    val clusterPort: Int,
+    val httpPort: Int,
+    val role: String
+)

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -32,8 +32,15 @@ data class SpectraDeviceResponse(
     val dataPath: String? = null
 ) : RioResponse()
 
+data class SpectraDeviceData(
+    val name: String,
+    val username: String,
+    val mgmtInterface: String,
+    val dataPath: String? = null
+)
+
 data class SpectraDeviceListResponse(
-    @JsonProperty("devices") val objects: List<SpectraDeviceResponse>,
+    @JsonProperty("devices") val objects: List<SpectraDeviceData>,
     val page: PageInfo
 ) : RioResponse()
 
@@ -56,8 +63,14 @@ data class DivaDeviceResponse(
     val username: String
 ) : RioResponse()
 
+data class DivaDeviceData(
+    val name: String,
+    val endpoint: String,
+    val username: String
+)
+
 data class DivaDeviceListResponse(
-    @JsonProperty("devices") val objects: List<DivaDeviceResponse>,
+    @JsonProperty("devices") val objects: List<DivaDeviceData>,
     val page: PageInfo
 ) : RioResponse()
 
@@ -101,18 +114,26 @@ data class FlashnetDeviceResponse(
     val host: String,
     val port: Int,
     val username: String,
-    val database: FlashnetDeviceDatabaseResponse
+    val database: FlashnetDeviceDatabaseData
 ) : RioResponse()
 
-data class FlashnetDeviceDatabaseResponse(
+data class FlashnetDeviceData(
+    val name: String,
+    val host: String,
+    val port: Int,
+    val username: String,
+    val database: FlashnetDeviceDatabaseData
+)
+
+data class FlashnetDeviceDatabaseData(
     val host: String,
     val port: String? = null,
     val username: String? = null,
     val name: String? = null
-) : RioResponse()
+)
 
 data class FlashnetDeviceListResponse(
-    @JsonProperty("devices") val objects: List<FlashnetDeviceResponse>,
+    @JsonProperty("devices") val objects: List<FlashnetDeviceData>,
     val page: PageInfo
 ) : RioResponse()
 
@@ -135,8 +156,14 @@ data class TbpfrDeviceResponse(
     val tempStorage: String
 ) : RioResponse()
 
+data class TbpfrDeviceData(
+    val name: String,
+    val endpoint: String,
+    val tempStorage: String
+)
+
 data class TbpfrDeviceListResponse(
-    @JsonProperty("devices") val objects: List<TbpfrDeviceResponse>,
+    @JsonProperty("devices") val objects: List<TbpfrDeviceData>,
     val page: PageInfo
 ) : RioResponse()
 
@@ -167,35 +194,15 @@ data class VailDeviceResponse(
     val accessKey: String
 ) : RioResponse()
 
+data class VailDeviceData(
+    val name: String,
+    val endpoint: String,
+    val port: Int? = null,
+    val https: Boolean,
+    val accessKey: String
+)
+
 data class VailDeviceListResponse(
-    @JsonProperty("devices") val objects: List<VailDeviceResponse>,
+    @JsonProperty("devices") val objects: List<VailDeviceData>,
     val page: PageInfo
 ) : RioResponse()
-
-sealed class EndpointDeviceCreateRequest(
-    open val name: String,
-    val type: String
-) : RioRequest
-
-data class FtpEndpointDeviceCreateRequest(
-    override val name: String,
-    val endpoint: String,
-    val username: String,
-    val password: String
-) : EndpointDeviceCreateRequest(name, "ftp")
-
-data class S3EndpointDeviceCreateRequest(
-    override val name: String,
-    val https: String,
-    val bucket: String,
-    @JsonProperty("access_id")
-    val accessId: String,
-    @JsonProperty("secret_key")
-    val secretKey: String,
-    val region: String
-) : EndpointDeviceCreateRequest(name, "s3")
-
-data class UriEndpointDeviceCreateRequest(
-    override val name: String,
-    val endpoint: String
-) : EndpointDeviceCreateRequest(name, "uri")

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -7,8 +7,36 @@ package com.spectralogic.rioclient
 
 import com.fasterxml.jackson.annotation.JsonProperty
 
+sealed class EndpointDeviceCreateRequest(
+    open val name: String,
+    val type: String
+) : RioRequest
+
+data class FtpEndpointDeviceCreateRequest(
+    override val name: String,
+    val endpoint: String,
+    val username: String,
+    val password: String
+) : EndpointDeviceCreateRequest(name, "ftp")
+
+data class S3EndpointDeviceCreateRequest(
+    override val name: String,
+    val https: String,
+    val bucket: String,
+    @JsonProperty("access_id")
+    val accessId: String,
+    @JsonProperty("secret_key")
+    val secretKey: String,
+    val region: String
+) : EndpointDeviceCreateRequest(name, "s3")
+
+data class UriEndpointDeviceCreateRequest(
+    override val name: String,
+    val endpoint: String
+) : EndpointDeviceCreateRequest(name, "uri")
+
 data class EndpointDeviceListResponse(
-    @JsonProperty("devices") val objects: List<EndpointGenericDeviceResponse>,
+    @JsonProperty("devices") val objects: List<EndpointGenericDeviceData>,
     val page: PageInfo
 ) : RioResponse()
 
@@ -17,10 +45,20 @@ sealed class EndpointDeviceResponse(
     open val type: String
 ) : RioResponse()
 
+sealed class EndpointDeviceData(
+    open val name: String,
+    open val type: String
+)
+
 data class EndpointGenericDeviceResponse(
     override val name: String,
     override val type: String
 ) : EndpointDeviceResponse(name, type)
+
+open class EndpointGenericDeviceData(
+    override val name: String,
+    override val type: String
+) : EndpointDeviceData(name, type)
 
 data class EndpointFtpDeviceResponse(
     override val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/Job.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Job.kt
@@ -58,6 +58,21 @@ open class JobResponse(
     val priority: String? = null
 ) : RioResponse()
 
+data class JobData(
+    val name: String?,
+    val id: UUID,
+    val creationDate: String,
+    val lastUpdated: String,
+    val status: JobStatus,
+    val jobType: JobType,
+    val numberOfFiles: Long,
+    val filesTransferred: Long,
+    val totalSizeInBytes: Long,
+    val progress: Float,
+    val foreignJobs: Map<UUID, ForeignJobDetails> = mapOf(),
+    val priority: String? = null
+)
+
 enum class JobType {
     ARCHIVE, RESTORE
 }
@@ -68,7 +83,7 @@ data class ForeignJobDetails(
 )
 
 data class JobListResponse(
-    val jobs: List<JobResponse>,
+    val jobs: List<JobData>,
     val page: PageInfo
 ) : RioResponse()
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
@@ -13,7 +13,13 @@ data class LogsetResponse(
     val creationDate: String
 ) : RioResponse()
 
+data class LogsetData(
+    val id: String,
+    val status: String,
+    val creationDate: String
+)
+
 data class LogsetListResponse(
-    @JsonProperty("logs") val objects: List<LogsetResponse>,
+    @JsonProperty("logs") val objects: List<LogsetData>,
     val page: PageInfo
 ) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Message.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Message.kt
@@ -18,6 +18,16 @@ data class MessageResponse(
     val severity: String
 ) : RioResponse()
 
+data class MessageData(
+    @JsonProperty("id") val messageId: UUID,
+    val creationDate: String,
+    val lastUpdated: String,
+    val read: Boolean,
+    val subject: MessageSubjectResponse,
+    val details: MessageDetailsResponse,
+    val severity: String
+)
+
 data class MessageSubjectResponse(
     val key: String,
     val parameters: Map<String, String>?,
@@ -35,6 +45,6 @@ data class MessageUpdateRequest(
 ) : RioRequest
 
 data class MessageListResponse(
-    @JsonProperty("data") val objects: List<MessageResponse>,
+    @JsonProperty("data") val objects: List<MessageData>,
     val page: PageInfo
 ) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Token.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Token.kt
@@ -29,12 +29,19 @@ open class TokenKeyResponse(
     val id: UUID
 ) : RioResponse()
 
+open class TokenKeyData(
+    val expirationDate: String? = null,
+    val creationDate: String,
+    val userName: String,
+    val id: UUID
+)
+
 open class ShortTokenResponse(
     val token: String
 ) : RioResponse()
 
 data class TokenListResponse(
-    @JsonProperty("data") val objects: List<TokenKeyResponse>,
+    @JsonProperty("data") val objects: List<TokenKeyData>,
     val page: PageInfo
 ) : RioResponse()
 


### PR DESCRIPTION
1 - Clean up: Moved endpoint device classes from Device.kt to Endpoint.kt
2 - Clean up: Renamed some objects from "Response" to "Data" to accurately reflect their usage
3 - Changed all ListResponse classes to use 'data' objects instead of a RioResponse objects

The ListResponse objects (e.g. BrokerListResponse) contained a list of single response objects (e.g. BrokerResponse) which have a statusCode element which is not appropriate within the list.  I discovered this issue downstream as RioBroker RioCLI tests were failing because Jackson parsing was failing with the elements in the list having an unexpected statusCode value

I tried to implement the data & response classes using a common interface and the ' by ' operator and it works, but that made things complicated downstream.  So I simply made a 'data' and 'response' classes that are identical but the latter implements RioResponse.  I am not happy with the redundancy, but it makes things cleaner for implementers of RioClient.