### PR TITLE
RioClient list response refactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ repositories {
 }
 
 dependencies {
-    val jacksonVersion = "2.13.+"
+    val jacksonVersion = "2.13.1"
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -6,7 +6,6 @@
 package com.spectralogic.rioclient
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
 data class BrokerCreateRequest(
@@ -169,16 +168,16 @@ data class ObjectUpdateRequest(
 data class Checksum(val hash: String, val type: String)
 
 data class ObjectListResponse(
-    val objects: List<ObjectData>,
+    override val objects: List<ObjectData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<ObjectData>(objects, page)
 
 data class BrokerListResponse(
-    @JsonProperty("brokers") val objects: List<BrokerData>,
+    val brokers: List<BrokerData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<BrokerData>(brokers, page)
 
 data class AgentListResponse(
-    @JsonProperty("agents") val objects: List<AgentData>,
+    val agents: List<AgentData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<AgentData>(agents, page)

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -168,7 +168,7 @@ data class ObjectUpdateRequest(
 data class Checksum(val hash: String, val type: String)
 
 data class ObjectListResponse(
-    override val objects: List<ObjectData>,
+    val objects: List<ObjectData>,
     val page: PageInfo
 ) : RioListResponse<ObjectData>(objects, page)
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -40,9 +40,9 @@ data class SpectraDeviceData(
 )
 
 data class SpectraDeviceListResponse(
-    @JsonProperty("devices") val objects: List<SpectraDeviceData>,
+    val devices: List<SpectraDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<SpectraDeviceData>(devices, page)
 
 data class DivaDeviceCreateRequest(
     val name: String,
@@ -70,9 +70,9 @@ data class DivaDeviceData(
 )
 
 data class DivaDeviceListResponse(
-    @JsonProperty("devices") val objects: List<DivaDeviceData>,
+    val devices: List<DivaDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<DivaDeviceData>(devices, page)
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class FlashnetDeviceCreateRequest(
@@ -133,9 +133,9 @@ data class FlashnetDeviceDatabaseData(
 )
 
 data class FlashnetDeviceListResponse(
-    @JsonProperty("devices") val objects: List<FlashnetDeviceData>,
+    val devices: List<FlashnetDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<FlashnetDeviceData>(devices, page)
 
 data class TbpfrDeviceCreateRequest(
     val name: String,
@@ -163,9 +163,9 @@ data class TbpfrDeviceData(
 )
 
 data class TbpfrDeviceListResponse(
-    @JsonProperty("devices") val objects: List<TbpfrDeviceData>,
+    val devices: List<TbpfrDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<TbpfrDeviceData>(devices, page)
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class VailDeviceCreateRequest(
@@ -203,6 +203,6 @@ data class VailDeviceData(
 )
 
 data class VailDeviceListResponse(
-    @JsonProperty("devices") val objects: List<VailDeviceData>,
+    val devices: List<VailDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<VailDeviceData>(devices, page)

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -36,9 +36,9 @@ data class UriEndpointDeviceCreateRequest(
 ) : EndpointDeviceCreateRequest(name, "uri")
 
 data class EndpointDeviceListResponse(
-    @JsonProperty("devices") val objects: List<EndpointGenericDeviceData>,
+    val devices: List<EndpointGenericDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<EndpointGenericDeviceData>(devices, page)
 
 sealed class EndpointDeviceResponse(
     open val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -21,6 +21,11 @@ open class RioResponse {
     var statusCode = HttpStatusCode.Processing
 }
 
+open class RioListResponse<T> (
+    open val objects: List<T>,
+    open val pageInfo: PageInfo
+) : RioResponse()
+
 class EmptyResponse : RioResponse()
 
 data class PageInfo(

--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -22,7 +22,7 @@ open class RioResponse {
 }
 
 open class RioListResponse<T> (
-    open val objects: List<T>,
+    open val objectList: List<T>,
     open val pageInfo: PageInfo
 ) : RioResponse()
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Job.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Job.kt
@@ -85,7 +85,7 @@ data class ForeignJobDetails(
 data class JobListResponse(
     val jobs: List<JobData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<JobData>(jobs, page)
 
 data class FileStatus(
     val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
@@ -5,8 +5,6 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 data class LogsetResponse(
     val id: String,
     val status: String,
@@ -20,6 +18,6 @@ data class LogsetData(
 )
 
 data class LogsetListResponse(
-    @JsonProperty("logs") val objects: List<LogsetData>,
+    val logs: List<LogsetData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<LogsetData>(logs, page)

--- a/src/main/kotlin/com/spectralogic/rioclient/Message.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Message.kt
@@ -45,6 +45,6 @@ data class MessageUpdateRequest(
 ) : RioRequest
 
 data class MessageListResponse(
-    @JsonProperty("data") val objects: List<MessageData>,
+    val data: List<MessageData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<MessageData>(data, page)

--- a/src/main/kotlin/com/spectralogic/rioclient/Token.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Token.kt
@@ -6,7 +6,6 @@
 package com.spectralogic.rioclient
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -41,9 +40,9 @@ open class ShortTokenResponse(
 ) : RioResponse()
 
 data class TokenListResponse(
-    @JsonProperty("data") val objects: List<TokenKeyData>,
+    val data: List<TokenKeyData>,
     val page: PageInfo
-) : RioResponse()
+) : RioListResponse<TokenKeyData>(data, page)
 
 data class UserLoginCredentials(
     val username: String,

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -111,7 +111,7 @@ class RioClient_Test {
         var listResponse = rioClient.listSpectraDevices()
         assertThat(listResponse.statusCode).isEqualTo(HttpStatusCode.OK)
         val spectraDeviceTotal = listResponse.page.totalItems
-        assertThat(listResponse.objects.map { it.name }).contains(spectraDeviceName)
+        assertThat(listResponse.devices.map { it.name }).contains(spectraDeviceName)
         assertThat(spectraDeviceTotal).isGreaterThanOrEqualTo(2)
 
         assertThat(rioClient.headSpectraDevice(spectraDeviceName)).isTrue
@@ -181,7 +181,7 @@ class RioClient_Test {
 
         listResponse = rioClient.listSpectraDevices()
         assertThat(listResponse.statusCode).isEqualTo(HttpStatusCode.OK)
-        assertThat(listResponse.objects.map { it.name }).doesNotContain(spectraDeviceName)
+        assertThat(listResponse.devices.map { it.name }).doesNotContain(spectraDeviceName)
         assertThat(rioClient.headSpectraDevice(spectraDeviceName)).isFalse
 
         // create unhappy path
@@ -508,8 +508,8 @@ class RioClient_Test {
         var endpointList = rioClient.listEndpointDevices()
         assertThat(endpointList.statusCode).isEqualTo(HttpStatusCode.OK)
         val endpointCount = endpointList.page.totalItems
-        assertThat(endpointList.objects.map { it.name }).contains(ftpName)
-        assertThat(endpointList.objects.map { it.name }).contains(uriName)
+        assertThat(endpointList.devices.map { it.name }).contains(ftpName)
+        assertThat(endpointList.devices.map { it.name }).contains(uriName)
         assertThat(endpointCount).isGreaterThanOrEqualTo(2)
 
         assertThat(rioClient.headEndpointDevice(ftpName)).isTrue
@@ -548,8 +548,8 @@ class RioClient_Test {
 
             val listBrokers = rioClient.listBrokers()
             assertThat(listBrokers.statusCode).isEqualTo(HttpStatusCode.OK)
-            assertThat(listBrokers.objects).isNotEmpty
-            assertThat(listBrokers.objects.map { it.name }).contains(testBroker)
+            assertThat(listBrokers.brokers).isNotEmpty
+            assertThat(listBrokers.brokers.map { it.name }).contains(testBroker)
 
             var getWriteAgent = rioClient.getAgent(testBroker, testAgent)
             assertThat(getWriteAgent.statusCode).isEqualTo(HttpStatusCode.OK)
@@ -560,8 +560,8 @@ class RioClient_Test {
 
             val listAgents = rioClient.listAgents(testBroker)
             assertThat(listAgents.statusCode).isEqualTo(HttpStatusCode.OK)
-            assertThat(listAgents.objects).hasSize(1)
-            assertThat(listAgents.objects.first().name).isEqualTo(getWriteAgent.name)
+            assertThat(listAgents.agents).hasSize(1)
+            assertThat(listAgents.agents.first().name).isEqualTo(getWriteAgent.name)
 
             val mapEntry = Pair("username", spectraDeviceAltUsername)
             val updateRequest = AgentUpdateRequest(mapOf(mapEntry))
@@ -922,7 +922,7 @@ class RioClient_Test {
         listLogs = rioClient.listLogsets()
         assertThat(listLogs.statusCode).isEqualTo(HttpStatusCode.OK)
         assertThat(listLogs.page.totalItems).isEqualTo(totalLogs + 1)
-        assertThat(listLogs.objects.map { it.id }).contains(newLog.id)
+        assertThat(listLogs.logs.map { it.id }).contains(newLog.id)
 
         val deleteLogSetResponse = rioClient.deleteLogset(UUID.fromString(newLog.id))
         assertThat(deleteLogSetResponse.statusCode).isEqualTo(HttpStatusCode.NoContent)
@@ -972,7 +972,7 @@ class RioClient_Test {
         listTokens = rioClient.listTokenKeys()
         assertThat(listTokens.statusCode).isEqualTo(HttpStatusCode.OK)
         assertThat(listTokens.page.totalItems).isEqualTo(totalTokens + 2)
-        assertThat(listTokens.objects.map { it.id }).containsAll(listOf(createToken.id, longToken.id))
+        assertThat(listTokens.data.map { it.id }).containsAll(listOf(createToken.id, longToken.id))
 
         assertThat(rioClient.headApiToken(createToken.id)).isTrue
         val deleteApiTokenResponse = rioClient.deleteApiToken(createToken.id)


### PR DESCRIPTION
On Feb-09 I removed the PageData interface, but RioCruise depends on this for its pageToFlow() method for getting all results.  So to upgrade RioCruise to the latest RioClient I need to put this interface back in.  I have changed the name to "RioListResponse" to conform with other naming conventions in RioClient and made it an extension of RioResponse to preserve the response status code logic.