### PR TITLE
ESCP-3621: Need to try setting the char set

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import io.ktor.client.HttpClient
 import io.ktor.client.call.receive
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.Charsets
 import io.ktor.client.features.ClientRequestException
 import io.ktor.client.features.HttpTimeout
 import io.ktor.client.features.json.JacksonSerializer
@@ -30,7 +31,6 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
 import io.ktor.http.contentType
-import io.ktor.http.withCharset
 import kotlinx.coroutines.runBlocking
 import nl.altindag.ssl.util.TrustManagerUtils
 import java.io.Closeable
@@ -58,6 +58,10 @@ class RioClient(
                 https {
                     this.trustManager = TrustManagerUtils.createUnsafeTrustManager()
                 }
+            }
+            Charsets {
+                register(Charsets.UTF_8)
+                sendCharset = Charsets.UTF_8
             }
             install(HttpTimeout) {
                 requestTimeoutMillis = requestTimeout
@@ -572,7 +576,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         val response: HttpResponse = try {
             get(urlStr) {
-                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
+                contentType(ContentType.Application.Json)
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             }
@@ -608,7 +612,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         return try {
             patch(url) {
-                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
+                contentType(ContentType.Application.Json)
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             } as HttpResponse
@@ -634,7 +638,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         val response: HttpResponse = try {
             post(urlStr) {
-                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
+                contentType(ContentType.Application.Json)
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             }
@@ -659,7 +663,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         val response: HttpResponse = try {
             put(urlStr) {
-                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
+                contentType(ContentType.Application.Json)
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             }

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -30,6 +30,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
 import io.ktor.http.contentType
+import io.ktor.http.withCharset
 import kotlinx.coroutines.runBlocking
 import nl.altindag.ssl.util.TrustManagerUtils
 import java.io.Closeable
@@ -571,7 +572,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         val response: HttpResponse = try {
             get(urlStr) {
-                contentType(ContentType.Application.Json)
+                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             }
@@ -607,7 +608,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         return try {
             patch(url) {
-                contentType(ContentType.Application.Json)
+                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             } as HttpResponse
@@ -633,7 +634,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         val response: HttpResponse = try {
             post(urlStr) {
-                contentType(ContentType.Application.Json)
+                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             }
@@ -658,7 +659,7 @@ class RioClient(
         val requestBody: Any = request ?: EmptyContent
         val response: HttpResponse = try {
             put(urlStr) {
-                contentType(ContentType.Application.Json)
+                contentType(ContentType.Application.Json.withCharset(Charsets.UTF_8))
                 header("Authorization", "Bearer ${tokenContainer.token}")
                 body = requestBody
             }


### PR DESCRIPTION
Not sure we are going to keep this, but I need to build a RioClient that sets the charset explicitly.
Another option would be to convert to Ktor client, but let's try this band-aid fix first.