### PR TITLE
Remove 'encoded' field from request since data sent to RioCruise from RioBroker is no longer encoded

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -173,7 +173,6 @@ data class ObjectListResponse(
 ) : RioListResponse<ObjectData>(objects, page)
 
 data class ObjectBatchHeadRequest(
-    val encoded: Boolean,
     val objects: List<String>
 ) : RioRequest
 

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -764,7 +764,7 @@ class RioClient_Test {
 
             assertThat(rioClient.objectExists(testBroker, objectName)).isTrue
 
-            val objectBatchHeadRequest = ObjectBatchHeadRequest(false, listOf(objectName, "bad-object-1", "bad-object-2"))
+            val objectBatchHeadRequest = ObjectBatchHeadRequest(listOf(objectName, "bad-object-1", "bad-object-2"))
             val objectBatchHeadResponse = rioClient.objectBatchHead(testBroker, objectBatchHeadRequest)
             assertThat(objectBatchHeadResponse.objects).hasSize(3)
             objectBatchHeadResponse.objects.forEach {


### PR DESCRIPTION
PRs for both RB and RC to follow