### PR TITLE
ESCP-3517: Archive file request update

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/Archive.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Archive.kt
@@ -21,5 +21,5 @@ data class FileToArchive(
     val size: Long?,
     val metadata: Map<String, String>? = null,
     val indexMedia: Boolean = false,
-    val `upload-new-files-only`: Boolean = true
+    val deleteAfterArchive: Boolean = false
 )


### PR DESCRIPTION
No idea why `upload-new-files-only` was a file level field when the option is at job level.  Removed.

Updated FileToArchive with new deleteAfterArchive field.   Once RioClient is updated I can flush out the test cases in RioBroker.