### PR TITLE
Upgrade ktor-client.  Add CVE suppression

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.6.10"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2")
 
-    val ktorVersion = "1.6.7"
+    val ktorVersion = "1.6.8"
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-jackson:$ktorVersion")
@@ -54,4 +54,5 @@ dependencies {
 dependencyCheck {
     // fail the build if any vulnerable dependencies are identified (CVSS score > 0)
     failBuildOnCVSS = 0f
+    suppressionFile = "project_files/owasp/dependency-check-suppression.xml"
 }

--- a/project_files/owasp/dependency-check-suppression.xml
+++ b/project_files/owasp/dependency-check-suppression.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+  <suppress base="true">
+    <notes><![CDATA[
+      file name: ktor-utils-metadata-1.6.8-all.jar
+      reason: SHA1 implementation in JetBrains Ktor Native before 2.0.1 was returning the same value.
+              An exact value or random number can be precisely predicted by observing previous values.
+      ]]></notes>
+    <packageUrl regex="true">^pkg:maven/io.ktor/ktor-utils@1.6.8$</packageUrl>
+    <cve>CVE-2022-29930</cve>
+  </suppress>
+</suppressions>


### PR DESCRIPTION
Suppressing CVE-2022-29930 related to SHA checksum and random number generation which RioClient does not use.
Would have rather upgraded Ktor-client to 2.0.1, but after starting down that path found it to be a bigger lift that I have time for right now.