### PR TITLE
Logging dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,9 +49,10 @@ dependencies {
     implementation("io.ktor:ktor-client-jackson:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
     implementation("io.ktor:ktor-client-auth:$ktorVersion")
-    implementation("io.github.hakky54:sslcontext-kickstart:7.0.3")
+    implementation("io.github.hakky54:sslcontext-kickstart:7.4.3")
 
-    implementation("org.apache.logging.log4j:log4j-api-kotlin:1.2.0")
+    implementation("io.github.microutils:kotlin-logging-jvm:2.1.20")
+
 
 
 // Test

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -51,7 +51,9 @@ class RioClient(
     private val verbose: Boolean = false
 ) : Closeable {
 
-    companion object: org.apache.logging.log4j.kotlin.Logging
+    companion object {
+        private val logger = mu.KotlinLogging.logger {}
+    }
 
     private data class MyMetadata(val metadata: Map<String, String>) : RioRequest
     private val api by lazy { "$rioUrl/api" }
@@ -89,6 +91,8 @@ class RioClient(
         install(Logging) {
             if (verbose) {
                 level = LogLevel.ALL
+            } else {
+                level = LogLevel.NONE
             }
         }
     }


### PR DESCRIPTION
Small change so we use the same version of the logging library as Rio uses for compatibility.