### PR TITLE
Remove unused variable made obsolete by PR #73

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -47,7 +47,6 @@ class RioClient(
     username: String = "spectra",
     password: String = "spectra",
     private val requestTimeout: Long = 60L * 1000L, // 60 seconds
-    longLivedToken: String? = null,
     private val verbose: Boolean = false
 ) : Closeable {
 


### PR DESCRIPTION
https://github.com/SpectraLogic/rio_client/pull/73

Next I will update RioCruise to remove the long lived token logic.