### PR TITLE
ESCP-3863: Upgrade RioClient to Ktor 2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     kotlin("jvm") version "1.8.0"
     kotlin("plugin.serialization") version "1.8.0"
-    id("org.jmailen.kotlinter") version "3.3.0"
+    id("org.jmailen.kotlinter") version "3.13.0"
     id("java")
     id("maven-publish")
     id("org.owasp.dependencycheck") version "6.3.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.8.0"
+    kotlin("plugin.serialization") version "1.8.0"
     id("org.jmailen.kotlinter") version "3.3.0"
     id("java")
     id("maven-publish")
@@ -38,21 +39,18 @@ repositories {
 }
 
 dependencies {
-    val jacksonVersion = "2.14.1"
-    implementation(platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
-    implementation("com.fasterxml.jackson.core:jackson-databind")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
-    val ktorVersion = "1.6.8"
+    val ktorVersion = "2.2.1"
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
-    implementation("io.ktor:ktor-client-jackson:$ktorVersion")
+    implementation("io.ktor:ktor-client-json:$ktorVersion")
     implementation("io.ktor:ktor-client-logging:$ktorVersion")
+    implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-client-auth:$ktorVersion")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+
     implementation("io.github.hakky54:sslcontext-kickstart:7.4.3")
     implementation("io.github.microutils:kotlin-logging-jvm:2.1.20")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
     id("org.owasp.dependencycheck") version "6.3.1"
 }
 
-group = "com.spectralogic"
-version = "1.2.1"
+group = "com.spectralogic.rioclient"
+version = "2.0.0"
 tasks {
     withType<JavaCompile> {
         options.encoding = "UTF-8"

--- a/src/main/kotlin/com/spectralogic/rioclient/Archive.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Archive.kt
@@ -5,10 +5,10 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import kotlinx.serialization.Serializable
 import java.net.URI
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class ArchiveRequest(
     val name: String? = null,
     val files: List<FileToArchive>,
@@ -16,9 +16,11 @@ data class ArchiveRequest(
     val callbacks: List<JobCallback>? = null
 ) : RioRequest
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+
+@Serializable
 data class FileToArchive(
     val name: String,
+    @Serializable(with = URISerializer::class)
     val uri: URI,
     val size: Long?,
     val metadata: Map<String, String>? = null,

--- a/src/main/kotlin/com/spectralogic/rioclient/Archive.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Archive.kt
@@ -16,7 +16,6 @@ data class ArchiveRequest(
     val callbacks: List<JobCallback>? = null
 ) : RioRequest
 
-
 @Serializable
 data class FileToArchive(
     val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -211,6 +211,7 @@ data class ObjectBatchHeadRequest(
 data class ObjectBatchHeadResponse(
     val objects: List<ObjectHeadData>
 ) : RioResponse()
+
 @Serializable
 data class ObjectHeadData(
     val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -5,9 +5,10 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import kotlinx.serialization.Serializable
 import java.util.UUID
 
+@Serializable
 data class BrokerCreateRequest(
     val name: String,
     val agentName: String,
@@ -15,26 +16,30 @@ data class BrokerCreateRequest(
     val agentType: String? = "bp_agent"
 ) : RioRequest
 
+@Serializable
 data class BrokerResponse(
     val name: String,
     val creationDate: String,
     val objectCount: Long
 ) : RioResponse()
 
+@Serializable
 data class BrokerData(
     val name: String,
     val creationDate: String,
     val objectCount: Long
 )
 
+@Serializable
 sealed class AgentConfig
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class BpAgentConfig(
     val bucket: String,
     val blackPearlName: String,
     val username: String,
     val createBucket: Boolean = false,
+    @Serializable(with = UUIDSerializer::class)
     val dataPolicyUUID: UUID? = null,
     val https: Boolean = false
 ) : AgentConfig()
@@ -50,6 +55,7 @@ fun BpAgentConfig.toConfigMap(): Map<String, String> {
     }
 }
 
+@Serializable
 data class VailAgentConfig(
     val vailDeviceName: String,
     val bucket: String
@@ -62,6 +68,7 @@ fun VailAgentConfig.toConfigMap(): Map<String, String> {
     }
 }
 
+@Serializable
 data class DivaAgentConfig(
     val divaDeviceName: String,
     val category: String,
@@ -78,6 +85,7 @@ fun DivaAgentConfig.toConfigMap(): Map<String, String> {
     }
 }
 
+@Serializable
 data class FlashnetAgentConfig(
     val flashnetDeviceName: String,
     val applicationName: String,
@@ -92,6 +100,7 @@ fun FlashnetAgentConfig.toConfigMap(): Map<String, String> {
     }
 }
 
+@Serializable
 data class SglLtfsAgentConfig(
     val bucket: String,
     val blackPearlName: String,
@@ -106,16 +115,19 @@ fun SglLtfsAgentConfig.toConfigMap(): Map<String, String> {
     }
 }
 
+@Serializable
 data class AgentCreateRequest(
     val name: String,
     val type: String,
     val agentConfig: Map<String, String>
 ) : RioRequest
 
+@Serializable
 data class AgentUpdateRequest(
     val agentConfig: Map<String, String>
 ) : RioRequest
 
+@Serializable
 data class AgentResponse(
     val name: String,
     val type: String,
@@ -126,6 +138,7 @@ data class AgentResponse(
     val indexState: String?
 ) : RioResponse()
 
+@Serializable
 data class AgentData(
     val name: String,
     val type: String,
@@ -136,6 +149,7 @@ data class AgentData(
     val indexState: String?
 )
 
+@Serializable
 data class ObjectResponse(
     val name: String,
     val size: Long,
@@ -146,6 +160,7 @@ data class ObjectResponse(
     val internalMetadata: Map<String, String>? = null
 ) : RioResponse()
 
+@Serializable
 data class ObjectData(
     val name: String,
     val size: Long,
@@ -156,43 +171,53 @@ data class ObjectData(
     val internalMetadata: Map<String, String>? = null
 )
 
+@Serializable
 data class ObjectBatchUpdateRequest(
     val objects: List<ObjectUpdateRequest>
 ) : RioRequest
 
+@Serializable
 data class ObjectUpdateRequest(
     val name: String,
     val metadata: Map<String, String>
 ) : RioRequest
 
+@Serializable
 data class Checksum(val hash: String, val type: String)
 
+@Serializable
 data class ObjectListResponse(
     val objects: List<ObjectData>,
     val page: PageInfo
 ) : RioListResponse<ObjectData>(objects, page)
 
+@Serializable
 data class ObjectCountResponse(
     val objectCount: Long
 ) : RioResponse()
 
+@Serializable
 data class ObjectBatchHeadRequest(
     val objects: List<String>
 ) : RioRequest
 
+@Serializable
 data class ObjectBatchHeadResponse(
     val objects: List<ObjectHeadData>
 ) : RioResponse()
+@Serializable
 data class ObjectHeadData(
     val name: String,
     val found: Boolean
 )
 
+@Serializable
 data class BrokerListResponse(
     val brokers: List<BrokerData>,
     val page: PageInfo
 ) : RioListResponse<BrokerData>(brokers, page)
 
+@Serializable
 data class AgentListResponse(
     val agents: List<AgentData>,
     val page: PageInfo

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -5,15 +5,18 @@
  */
 package com.spectralogic.rioclient
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class BrokerCreateRequest(
     val name: String,
     val agentName: String,
-    val agentConfig: AgentConfig,
-    val agentType: String? = "bp_agent"
+    val agentConfig: Map<String,String>,
+    @EncodeDefault val agentType: String = "bp_agent"
 ) : RioRequest
 
 @Serializable
@@ -31,41 +34,46 @@ data class BrokerData(
 )
 
 @Serializable
-sealed class AgentConfig
+sealed class AgentConfig {
+    abstract fun toConfigMap(): Map<String,String>
+}
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class BpAgentConfig(
     val bucket: String,
     val blackPearlName: String,
     val username: String,
-    val createBucket: Boolean = false,
+    @EncodeDefault val createBucket: Boolean = false,
     @Serializable(with = UUIDSerializer::class)
     val dataPolicyUUID: UUID? = null,
-    val https: Boolean = false
-) : AgentConfig()
-
-fun BpAgentConfig.toConfigMap(): Map<String, String> {
-    return buildMap(5) {
-        put("bucket", bucket)
-        put("blackPearlName", blackPearlName)
-        put("username", username)
-        put("createBucket", createBucket.toString())
-        put("https", https.toString())
-        if (dataPolicyUUID != null) put("dataPolicyUUID", dataPolicyUUID.toString())
+    @EncodeDefault val https: Boolean = false
+) : AgentConfig() {
+    override fun toConfigMap(): Map<String, String> {
+        return buildMap(5) {
+            put("bucket", bucket)
+            put("blackPearlName", blackPearlName)
+            put("username", username)
+            put("createBucket", createBucket.toString())
+            put("https", https.toString())
+            if (dataPolicyUUID != null) put("dataPolicyUUID", dataPolicyUUID.toString())
+        }
     }
+
 }
 
 @Serializable
 data class VailAgentConfig(
     val vailDeviceName: String,
     val bucket: String
-) : AgentConfig()
-
-fun VailAgentConfig.toConfigMap(): Map<String, String> {
-    return buildMap {
-        put("vailDeviceName", vailDeviceName)
-        put("bucket", bucket)
+) : AgentConfig() {
+    override fun toConfigMap(): Map<String, String> {
+        return buildMap {
+            put("vailDeviceName", vailDeviceName)
+            put("bucket", bucket)
+        }
     }
+
 }
 
 @Serializable
@@ -74,15 +82,16 @@ data class DivaAgentConfig(
     val category: String,
     val qos: Int?,
     val priority: Int?
-) : AgentConfig()
-
-fun DivaAgentConfig.toConfigMap(): Map<String, String> {
-    return buildMap {
-        put("divaDeviceName", divaDeviceName)
-        put("category", category)
-        if (qos != null) put("qos", qos.toString())
-        if (priority != null) put("priority", priority.toString())
+) : AgentConfig() {
+    override fun toConfigMap(): Map<String, String> {
+        return buildMap {
+            put("divaDeviceName", divaDeviceName)
+            put("category", category)
+            if (qos != null) put("qos", qos.toString())
+            if (priority != null) put("priority", priority.toString())
+        }
     }
+
 }
 
 @Serializable
@@ -90,14 +99,14 @@ data class FlashnetAgentConfig(
     val flashnetDeviceName: String,
     val applicationName: String,
     val storageGroupName: String
-)
+) : AgentConfig() {
+    override fun toConfigMap(): Map<String, String> {
+        return buildMap {
+            put("flashnetDeviceName", flashnetDeviceName)
+            put("applicationName", applicationName)
+            put("storageGroupName", storageGroupName)
+        }    }
 
-fun FlashnetAgentConfig.toConfigMap(): Map<String, String> {
-    return buildMap {
-        put("flashnetDeviceName", flashnetDeviceName)
-        put("applicationName", applicationName)
-        put("storageGroupName", storageGroupName)
-    }
 }
 
 @Serializable
@@ -105,13 +114,13 @@ data class SglLtfsAgentConfig(
     val bucket: String,
     val blackPearlName: String,
     val username: String
-)
-
-fun SglLtfsAgentConfig.toConfigMap(): Map<String, String> {
-    return buildMap {
-        put("bucket", bucket)
-        put("blackPearlName", blackPearlName)
-        put("username", username)
+) : AgentConfig() {
+    override fun toConfigMap(): Map<String, String> {
+        return buildMap {
+            put("bucket", bucket)
+            put("blackPearlName", blackPearlName)
+            put("username", username)
+        }
     }
 }
 
@@ -143,10 +152,10 @@ data class AgentData(
     val name: String,
     val type: String,
     val creationDate: String,
-    val lastIndexDate: String?,
+    val lastIndexDate: String? = null,
     val writable: Boolean,
     val agentConfig: Map<String, String>,
-    val indexState: String?
+    val indexState: String? = null
 )
 
 @Serializable

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -132,10 +132,10 @@ data class AgentResponse(
     val name: String,
     val type: String,
     val creationDate: String,
-    val lastIndexDate: String?,
+    val lastIndexDate: String? = null,
     val writable: Boolean,
     val agentConfig: Map<String, String>,
-    val indexState: String?
+    val indexState: String? = null
 ) : RioResponse()
 
 @Serializable
@@ -189,7 +189,7 @@ data class Checksum(val hash: String, val type: String)
 data class ObjectListResponse(
     val objects: List<ObjectData>,
     val page: PageInfo
-) : RioListResponse<ObjectData>(objects, page)
+) : RioResponse()
 
 @Serializable
 data class ObjectCountResponse(
@@ -215,10 +215,10 @@ data class ObjectHeadData(
 data class BrokerListResponse(
     val brokers: List<BrokerData>,
     val page: PageInfo
-) : RioListResponse<BrokerData>(brokers, page)
+) : RioResponse()
 
 @Serializable
 data class AgentListResponse(
     val agents: List<AgentData>,
     val page: PageInfo
-) : RioListResponse<AgentData>(agents, page)
+) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 data class BrokerCreateRequest(
     val name: String,
     val agentName: String,
-    val agentConfig: Map<String,String>,
+    val agentConfig: Map<String, String>,
     @EncodeDefault val agentType: String = "bp_agent"
 ) : RioRequest
 
@@ -35,7 +35,7 @@ data class BrokerData(
 
 @Serializable
 sealed class AgentConfig {
-    abstract fun toConfigMap(): Map<String,String>
+    abstract fun toConfigMap(): Map<String, String>
 }
 
 @Serializable
@@ -59,7 +59,6 @@ data class BpAgentConfig(
             if (dataPolicyUUID != null) put("dataPolicyUUID", dataPolicyUUID.toString())
         }
     }
-
 }
 
 @Serializable
@@ -73,7 +72,6 @@ data class VailAgentConfig(
             put("bucket", bucket)
         }
     }
-
 }
 
 @Serializable
@@ -91,7 +89,6 @@ data class DivaAgentConfig(
             if (priority != null) put("priority", priority.toString())
         }
     }
-
 }
 
 @Serializable
@@ -105,8 +102,8 @@ data class FlashnetAgentConfig(
             put("flashnetDeviceName", flashnetDeviceName)
             put("applicationName", applicationName)
             put("storageGroupName", storageGroupName)
-        }    }
-
+        }
+    }
 }
 
 @Serializable

--- a/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
@@ -5,14 +5,19 @@
  */
 package com.spectralogic.rioclient
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class ClusterResponse(
     val clusterName: String
 ) : RioResponse()
 
+@Serializable
 data class ClusterMembersListResponse(
     val clusterMembers: List<ClusterMemberData>
 ) : RioResponse()
 
+@Serializable
 data class ClusterMemberResponse(
     val memberId: String,
     val ipAddress: String,
@@ -21,6 +26,7 @@ data class ClusterMemberResponse(
     val role: String
 ) : RioResponse()
 
+@Serializable
 data class ClusterMemberData(
     val memberId: String,
     val ipAddress: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class SpectraDeviceCreateRequest(
     val name: String,
@@ -19,7 +18,6 @@ data class SpectraDeviceCreateRequest(
     val dataPath: String? = null
 ) : RioRequest
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class SpectraDeviceUpdateRequest(
     val mgmtInterface: String,
@@ -48,7 +46,7 @@ data class SpectraDeviceData(
 data class SpectraDeviceListResponse(
     val devices: List<SpectraDeviceData>,
     val page: PageInfo
-) : RioListResponse<SpectraDeviceData>(devices, page)
+) : RioResponse()
 
 @Serializable
 data class DivaDeviceCreateRequest(
@@ -83,9 +81,8 @@ data class DivaDeviceData(
 data class DivaDeviceListResponse(
     val devices: List<DivaDeviceData>,
     val page: PageInfo
-) : RioListResponse<DivaDeviceData>(devices, page)
+) : RioResponse()
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class FlashnetDeviceCreateRequest(
     val name: String,
@@ -104,7 +101,6 @@ data class FlashnetDeviceCreateRequest(
     val databaseName: String? = null
 ) : RioRequest
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class FlashnetDeviceUpdateRequest(
     val host: String,
@@ -152,7 +148,7 @@ data class FlashnetDeviceDatabaseData(
 data class FlashnetDeviceListResponse(
     val devices: List<FlashnetDeviceData>,
     val page: PageInfo
-) : RioListResponse<FlashnetDeviceData>(devices, page)
+) : RioResponse()
 
 @Serializable
 data class TbpfrDeviceCreateRequest(
@@ -187,9 +183,8 @@ data class TbpfrDeviceData(
 data class TbpfrDeviceListResponse(
     val devices: List<TbpfrDeviceData>,
     val page: PageInfo
-) : RioListResponse<TbpfrDeviceData>(devices, page)
+) : RioResponse()
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class VailDeviceCreateRequest(
     val name: String,
@@ -200,7 +195,6 @@ data class VailDeviceCreateRequest(
     val https: String
 ) : RioRequest
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class VailDeviceUpdateRequest(
     val accessKey: String,
@@ -232,7 +226,7 @@ data class VailDeviceData(
 data class VailDeviceListResponse(
     val devices: List<VailDeviceData>,
     val page: PageInfo
-) : RioListResponse<VailDeviceData>(devices, page)
+) : RioResponse()
 
 @Serializable
 data class DeviceObjectListResponse(

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -5,10 +5,12 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class SpectraDeviceCreateRequest(
     val name: String,
     val mgmtInterface: String,
@@ -17,7 +19,8 @@ data class SpectraDeviceCreateRequest(
     val dataPath: String? = null
 ) : RioRequest
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class SpectraDeviceUpdateRequest(
     val mgmtInterface: String,
     val username: String,
@@ -25,6 +28,7 @@ data class SpectraDeviceUpdateRequest(
     val dataPath: String? = null
 ) : RioRequest
 
+@Serializable
 data class SpectraDeviceResponse(
     val name: String,
     val username: String,
@@ -32,6 +36,7 @@ data class SpectraDeviceResponse(
     val dataPath: String? = null
 ) : RioResponse()
 
+@Serializable
 data class SpectraDeviceData(
     val name: String,
     val username: String,
@@ -39,11 +44,13 @@ data class SpectraDeviceData(
     val dataPath: String? = null
 )
 
+@Serializable
 data class SpectraDeviceListResponse(
     val devices: List<SpectraDeviceData>,
     val page: PageInfo
 ) : RioListResponse<SpectraDeviceData>(devices, page)
 
+@Serializable
 data class DivaDeviceCreateRequest(
     val name: String,
     val endpoint: String,
@@ -51,64 +58,71 @@ data class DivaDeviceCreateRequest(
     val password: String
 ) : RioRequest
 
+@Serializable
 data class DivaDeviceUpdateRequest(
     val endpoint: String,
     val username: String,
     val password: String
 ) : RioRequest
 
+@Serializable
 data class DivaDeviceResponse(
     val name: String,
     val endpoint: String,
     val username: String
 ) : RioResponse()
 
+@Serializable
 data class DivaDeviceData(
     val name: String,
     val endpoint: String,
     val username: String
 )
 
+@Serializable
 data class DivaDeviceListResponse(
     val devices: List<DivaDeviceData>,
     val page: PageInfo
 ) : RioListResponse<DivaDeviceData>(devices, page)
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class FlashnetDeviceCreateRequest(
     val name: String,
     val host: String,
     val port: Int?,
     val username: String,
-    @JsonProperty("database_host")
+    @SerialName("database_host")
     val databaseHost: String,
-    @JsonProperty("database_port")
+    @SerialName("database_port")
     val databasePort: Int? = null,
-    @JsonProperty("database_username")
+    @SerialName("database_username")
     val databaseUsername: String? = null,
-    @JsonProperty("database_password")
+    @SerialName("database_password")
     val databasePassword: String? = null,
-    @JsonProperty("database_name")
+    @SerialName("database_name")
     val databaseName: String? = null
 ) : RioRequest
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class FlashnetDeviceUpdateRequest(
     val host: String,
     val port: Int?,
     val username: String,
-    @JsonProperty("database_host")
+    @SerialName("database_host")
     val databaseHost: String,
-    @JsonProperty("database_port")
+    @SerialName("database_port")
     val databasePort: Int? = null,
-    @JsonProperty("database_username")
+    @SerialName("database_username")
     val databaseUsername: String? = null,
-    @JsonProperty("database_password")
+    @SerialName("database_password")
     val databasePassword: String? = null,
-    @JsonProperty("database_name")
+    @SerialName("database_name")
     val databaseName: String? = null
 ) : RioRequest
 
+@Serializable
 data class FlashnetDeviceResponse(
     val name: String,
     val host: String,
@@ -117,6 +131,7 @@ data class FlashnetDeviceResponse(
     val database: FlashnetDeviceDatabaseData
 ) : RioResponse()
 
+@Serializable
 data class FlashnetDeviceData(
     val name: String,
     val host: String,
@@ -125,6 +140,7 @@ data class FlashnetDeviceData(
     val database: FlashnetDeviceDatabaseData
 )
 
+@Serializable
 data class FlashnetDeviceDatabaseData(
     val host: String,
     val port: String? = null,
@@ -132,11 +148,13 @@ data class FlashnetDeviceDatabaseData(
     val name: String? = null
 )
 
+@Serializable
 data class FlashnetDeviceListResponse(
     val devices: List<FlashnetDeviceData>,
     val page: PageInfo
 ) : RioListResponse<FlashnetDeviceData>(devices, page)
 
+@Serializable
 data class TbpfrDeviceCreateRequest(
     val name: String,
     val endpoint: String,
@@ -144,30 +162,35 @@ data class TbpfrDeviceCreateRequest(
     val allowLazyIndex: Boolean = false
 ) : RioRequest
 
+@Serializable
 data class TbpfrDeviceUpdateRequest(
     val endpoint: String,
     val tempStorage: String,
     val allowLazyIndex: Boolean = false
 ) : RioRequest
 
+@Serializable
 data class TbpfrDeviceResponse(
     val name: String,
     val endpoint: String,
     val tempStorage: String
 ) : RioResponse()
 
+@Serializable
 data class TbpfrDeviceData(
     val name: String,
     val endpoint: String,
     val tempStorage: String
 )
 
+@Serializable
 data class TbpfrDeviceListResponse(
     val devices: List<TbpfrDeviceData>,
     val page: PageInfo
 ) : RioListResponse<TbpfrDeviceData>(devices, page)
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class VailDeviceCreateRequest(
     val name: String,
     val accessKey: String,
@@ -177,7 +200,8 @@ data class VailDeviceCreateRequest(
     val https: String
 ) : RioRequest
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class VailDeviceUpdateRequest(
     val accessKey: String,
     val secretKey: String,
@@ -186,6 +210,7 @@ data class VailDeviceUpdateRequest(
     val https: String
 ) : RioRequest
 
+@Serializable
 data class VailDeviceResponse(
     val name: String,
     val endpoint: String,
@@ -194,6 +219,7 @@ data class VailDeviceResponse(
     val accessKey: String
 ) : RioResponse()
 
+@Serializable
 data class VailDeviceData(
     val name: String,
     val endpoint: String,
@@ -202,11 +228,13 @@ data class VailDeviceData(
     val accessKey: String
 )
 
+@Serializable
 data class VailDeviceListResponse(
     val devices: List<VailDeviceData>,
     val page: PageInfo
 ) : RioListResponse<VailDeviceData>(devices, page)
 
+@Serializable
 data class DeviceObjectListResponse(
     val objects: List<String>,
     val isTruncated: Boolean

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -8,7 +8,6 @@ package com.spectralogic.rioclient
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-
 @Serializable
 data class SpectraDeviceCreateRequest(
     val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -5,20 +5,25 @@
  */
 package com.spectralogic.rioclient
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-sealed class EndpointDeviceCreateRequest(
-    open val name: String,
+interface EndpointDeviceCreateRequest {
+    val name: String
     val type: String
-) : RioRequest
+}
 
+@Serializable
 data class FtpEndpointDeviceCreateRequest(
     override val name: String,
     val endpoint: String,
     val username: String,
-    val password: String
-) : EndpointDeviceCreateRequest(name, "ftp")
+    val password: String,
+    @EncodeDefault override val type: String = "ftp"
+) : EndpointDeviceCreateRequest, RioRequest
 
+@Serializable
 data class S3EndpointDeviceCreateRequest(
     override val name: String,
     val https: String,
@@ -27,46 +32,54 @@ data class S3EndpointDeviceCreateRequest(
     val accessId: String,
     @SerialName("secret_key")
     val secretKey: String,
-    val region: String
-) : EndpointDeviceCreateRequest(name, "s3")
+    val region: String,
+    @EncodeDefault override val type: String = "s3"
+) : EndpointDeviceCreateRequest, RioRequest
 
+@Serializable
 data class UriEndpointDeviceCreateRequest(
     override val name: String,
-    val endpoint: String
-) : EndpointDeviceCreateRequest(name, "uri")
+    val endpoint: String,
+    @EncodeDefault override val type: String = "uri"
+) : EndpointDeviceCreateRequest, RioRequest
 
+@Serializable
 data class EndpointDeviceListResponse(
     val devices: List<EndpointGenericDeviceData>,
     val page: PageInfo
 ) : RioResponse()
 
-sealed class EndpointDeviceResponse(
-    open val name: String,
-    open val type: String
-) : RioResponse()
+interface EndpointDeviceResponse {
+    val name: String
+    val type: String
+}
 
-sealed class EndpointDeviceData(
-    open val name: String,
-    open val type: String
-)
+interface EndpointDeviceData {
+    val name: String
+    val type: String
+}
 
+@Serializable
 data class EndpointGenericDeviceResponse(
     override val name: String,
     override val type: String
-) : EndpointDeviceResponse(name, type)
+) : EndpointDeviceResponse, RioResponse()
 
+@Serializable
 open class EndpointGenericDeviceData(
     override val name: String,
     override val type: String
-) : EndpointDeviceData(name, type)
+) : EndpointDeviceData
 
+@Serializable
 data class EndpointFtpDeviceResponse(
     override val name: String,
     override val type: String,
     val endpoint: String,
     val username: String
-) : EndpointDeviceResponse(name, type)
+) : EndpointDeviceResponse, RioResponse()
 
+@Serializable
 data class EndpointS3DeviceResponse(
     override val name: String,
     override val type: String,
@@ -76,10 +89,11 @@ data class EndpointS3DeviceResponse(
     @SerialName("secret_key")
     val secretKey: String,
     val region: String
-) : EndpointDeviceResponse(name, type)
+) : EndpointDeviceResponse, RioResponse()
 
+@Serializable
 data class EndpointUriDeviceResponse(
     override val name: String,
     override val type: String,
     val endpoint: String,
-) : EndpointDeviceResponse(name, type)
+) : EndpointDeviceResponse, RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -5,7 +5,7 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import kotlinx.serialization.SerialName
 
 sealed class EndpointDeviceCreateRequest(
     open val name: String,
@@ -23,9 +23,9 @@ data class S3EndpointDeviceCreateRequest(
     override val name: String,
     val https: String,
     val bucket: String,
-    @JsonProperty("access_id")
+    @SerialName("access_id")
     val accessId: String,
-    @JsonProperty("secret_key")
+    @SerialName("secret_key")
     val secretKey: String,
     val region: String
 ) : EndpointDeviceCreateRequest(name, "s3")
@@ -71,9 +71,9 @@ data class EndpointS3DeviceResponse(
     override val name: String,
     override val type: String,
     val https: String,
-    @JsonProperty("access_id")
+    @SerialName("access_id")
     val accessId: String,
-    @JsonProperty("secret_key")
+    @SerialName("secret_key")
     val secretKey: String,
     val region: String
 ) : EndpointDeviceResponse(name, type)

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -95,5 +95,5 @@ data class EndpointS3DeviceResponse(
 data class EndpointUriDeviceResponse(
     override val name: String,
     override val type: String,
-    val endpoint: String,
+    val endpoint: String
 ) : EndpointDeviceResponse, RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -38,7 +38,7 @@ data class UriEndpointDeviceCreateRequest(
 data class EndpointDeviceListResponse(
     val devices: List<EndpointGenericDeviceData>,
     val page: PageInfo
-) : RioListResponse<EndpointGenericDeviceData>(devices, page)
+) : RioResponse()
 
 sealed class EndpointDeviceResponse(
     open val name: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -66,14 +66,14 @@ interface RioErrorMessage {
 
 @Serializable
 data class RioDefaultErrorMessage
-constructor (
+constructor(
     override val message: String,
     override val statusCode: Int
 ) : RioErrorMessage
 
 @Serializable
 data class RioResourceErrorMessage
-constructor (
+constructor(
     override val message: String,
     override val statusCode: Int,
     val resourceName: String,
@@ -82,7 +82,7 @@ constructor (
 
 @Serializable
 data class RioValidationErrorMessage
-constructor (
+constructor(
     override val message: String,
     override val statusCode: Int,
     val errors: List<RioValidationMessage>
@@ -90,7 +90,7 @@ constructor (
 
 @Serializable
 data class RioValidationMessage
-constructor (
+constructor(
     val fieldName: String,
     val fieldType: String,
     val errorType: String,
@@ -100,7 +100,7 @@ constructor (
 
 @Serializable
 data class RioUnsupportedMediaErrorMessage
-constructor (
+constructor(
     override val message: String,
     override val statusCode: Int,
     val suppliedMediaType: String,
@@ -109,7 +109,7 @@ constructor (
 
 @Serializable
 data class RioDownstreamErrorMessage
-constructor (
+constructor(
     override val message: String,
     override val statusCode: Int,
     val resourceName: String?,

--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -5,29 +5,33 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.ObjectMapper
-import io.ktor.client.features.ClientRequestException
-import io.ktor.client.features.ServerResponseException
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
-val mapper = ObjectMapper()
 
 interface RioRequest
 
+@Serializable
 open class RioResponse {
+    @Serializable(with = HttpStatusCodeSerializer::class)
     var statusCode = HttpStatusCode.Processing
 }
 
+@Serializable
 open class RioListResponse<T> (
     open val objectList: List<T>,
     open val pageInfo: PageInfo
 ) : RioResponse()
 
+@Serializable
 class EmptyResponse : RioResponse()
 
+@Serializable
 data class PageInfo(
     val number: Long,
     val pageSize: Long,
@@ -60,16 +64,15 @@ class RioHttpException(
     fun errorMessage(): RioErrorMessage {
         if (errorResponse.isNotBlank()) {
             listOf(
-                RioResourceErrorMessage::class.java,
-                RioValidationErrorMessage::class.java,
-                RioUnsupportedMediaError::class.java,
-                RioDownstreamErrorMessage::class.java,
-                RioDefaultErrorMessage::class.java
+                RioResourceErrorMessageSerializer,
+                RioValidationErrorMessageSerializer,
+                RioUnsupportedMediaErrorSerializer,
+                /*RioDownstreamErrorMessageSerializer,
+                RioDefaultErrorMessageSerializer*/
             ).forEach {
                 try {
-                    return mapper.readValue(errorResponse, it)
-                } catch (t: Throwable) {
-                }
+                    return Json.decodeFromString(it, errorResponse)
+                } catch (_: Throwable) { }
             }
         }
         return RioDefaultErrorMessage("${cause.message}", statusCode.value)
@@ -81,72 +84,55 @@ interface RioErrorMessage {
     val statusCode: Int
 }
 
+@Serializable
 data class RioDefaultErrorMessage
-@JsonCreator constructor (
-    @JsonProperty("message")
+constructor (
     override val message: String,
-    @JsonProperty("statusCode")
     override val statusCode: Int
 ) : RioErrorMessage
 
+@Serializable
 data class RioResourceErrorMessage
-@JsonCreator constructor (
-    @JsonProperty("message")
+constructor (
     override val message: String,
-    @JsonProperty("statusCode")
     override val statusCode: Int,
-    @JsonProperty("resourceName")
     val resourceName: String,
-    @JsonProperty("resourceType")
     val resourceType: String
 ) : RioErrorMessage
 
+@Serializable
 data class RioValidationErrorMessage
-@JsonCreator constructor (
-    @JsonProperty("message")
+constructor (
     override val message: String,
-    @JsonProperty("statusCode")
     override val statusCode: Int,
-    @JsonProperty("errors")
     val errors: List<RioValidationMessage>
 ) : RioErrorMessage
 
+@Serializable
 data class RioValidationMessage
-@JsonCreator constructor (
-    @JsonProperty("fieldName")
+constructor (
     val fieldName: String,
-    @JsonProperty("fieldType")
     val fieldType: String,
-    @JsonProperty("errorType")
     val errorType: String,
-    @JsonProperty("value")
     val value: String? = null,
-    @JsonProperty("reason")
     val reason: String? = null
 )
 
-data class RioUnsupportedMediaError
-@JsonCreator constructor (
-    @JsonProperty("message")
+@Serializable
+data class RioUnsupportedMediaErrorMessage
+constructor (
     override val message: String,
-    @JsonProperty("statusCode")
     override val statusCode: Int,
-    @JsonProperty("suppliedMediaType")
     val suppliedMediaType: String,
-    @JsonProperty("supportedMediaType")
     val supportedMediaType: String
 ) : RioErrorMessage
 
+@Serializable
 data class RioDownstreamErrorMessage
-@JsonCreator constructor (
-    @JsonProperty("message")
+constructor (
     override val message: String,
-    @JsonProperty("statusCode")
     override val statusCode: Int,
-    @JsonProperty("resourceName")
     val resourceName: String?,
-    @JsonProperty("resourceType")
     val resourceType: String,
-    @JsonProperty("cause")
     val cause: String
 ) : RioErrorMessage

--- a/src/main/kotlin/com/spectralogic/rioclient/Job.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Job.kt
@@ -24,37 +24,24 @@ data class JobCallback(
     val eventType: String
 )
 
-// TODO: Serializable ???
-class DetailedJobResponse(
-    name: String?,
-    id: UUID,
-    creationDate: String,
-    lastUpdated: String,
-    status: JobStatus,
-    jobType: JobType,
-    numberOfFiles: Long,
-    filesTransferred: Long,
-    totalSizeInBytes: Long,
-    progress: Float,
+@Serializable
+open class DetailedJobResponse(
+    val name: String?,
+    @Serializable(with = UUIDSerializer::class)
+    val id: UUID,
+    val creationDate: String,
+    val lastUpdated: String,
+    val status: JobStatus,
+    val jobType: JobType,
+    val numberOfFiles: Long,
+    val filesTransferred: Long,
+    val totalSizeInBytes: Long,
+    val progress: Float,
     val files: List<FileStatus>,
-    foreignJobs: Map<UUID, ForeignJobDetails> = emptyMap(),
-    priority: String? = null,
-    callbacks: List<JobCallback>? = null
-) : JobResponse(
-    name,
-    id,
-    creationDate,
-    lastUpdated,
-    status,
-    jobType,
-    numberOfFiles,
-    filesTransferred,
-    totalSizeInBytes,
-    progress,
-    foreignJobs,
-    priority,
-    callbacks = callbacks
-)
+    val foreignJobs: Map<@Serializable(with = UUIDSerializer::class)UUID, ForeignJobDetails> = emptyMap(),
+    val priority: String? = null,
+    val callbacks: List<JobCallback>? = null
+) : RioResponse()
 
 @Serializable
 open class JobResponse(
@@ -108,7 +95,7 @@ data class ForeignJobDetails(
 data class JobListResponse(
     val jobs: List<JobData>,
     val page: PageInfo
-) : RioListResponse<JobData>(jobs, page)
+) : RioResponse()
 
 @Serializable
 data class FileStatus(
@@ -122,7 +109,7 @@ data class FileStatus(
     val sizeInBytes: Long,
     val lastUpdated: String,
     val broker: String?,
-    val agentName: String?,
+    val agent: String?,
     val fileId: String
 )
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Job.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Job.kt
@@ -5,22 +5,26 @@
  */
 package com.spectralogic.rioclient
 
+import kotlinx.serialization.Serializable
 import java.net.URI
 import java.util.Collections.emptyMap
 import java.util.UUID
 
+@Serializable
 data class JobStatus(
     val message: String,
     val status: String,
     val reason: String? = null
 )
 
+@Serializable
 data class JobCallback(
     val url: String,
     val eventClass: String,
     val eventType: String
 )
 
+// TODO: Serializable ???
 class DetailedJobResponse(
     name: String?,
     id: UUID,
@@ -52,8 +56,10 @@ class DetailedJobResponse(
     callbacks = callbacks
 )
 
+@Serializable
 open class JobResponse(
     val name: String?,
+    @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val creationDate: String,
     val lastUpdated: String,
@@ -63,14 +69,16 @@ open class JobResponse(
     val filesTransferred: Long,
     val totalSizeInBytes: Long,
     val progress: Float,
-    val foreignJobs: Map<UUID, ForeignJobDetails> = emptyMap(),
+    val foreignJobs: Map<@Serializable(with = UUIDSerializer::class)UUID, ForeignJobDetails> = emptyMap(),
     val priority: String? = null,
     val sessionId: String? = null,
     val callbacks: List<JobCallback>? = null
 ) : RioResponse()
 
+@Serializable
 data class JobData(
     val name: String?,
+    @Serializable(with = UUIDSerializer::class)
     val id: UUID,
     val creationDate: String,
     val lastUpdated: String,
@@ -80,30 +88,36 @@ data class JobData(
     val filesTransferred: Long,
     val totalSizeInBytes: Long,
     val progress: Float,
-    val foreignJobs: Map<UUID, ForeignJobDetails> = emptyMap(),
+    val foreignJobs: Map<@Serializable(with = UUIDSerializer::class)UUID, ForeignJobDetails> = emptyMap(),
     val priority: String? = null,
     val callbacks: List<JobCallback>? = null
 )
 
+@Serializable
 enum class JobType {
     ARCHIVE, RESTORE
 }
 
+@Serializable
 data class ForeignJobDetails(
     val id: String,
     val type: String
 )
 
+@Serializable
 data class JobListResponse(
     val jobs: List<JobData>,
     val page: PageInfo
 ) : RioListResponse<JobData>(jobs, page)
 
+@Serializable
 data class FileStatus(
     val name: String,
     val status: String,
     val statusMessage: String,
+    @Serializable(with = UUIDSerializer::class)
     val foreignJob: UUID? = null,
+    @Serializable(with = URISerializer::class)
     val uri: URI,
     val sizeInBytes: Long,
     val lastUpdated: String,
@@ -112,17 +126,21 @@ data class FileStatus(
     val fileId: String
 )
 
+@Serializable
 data class FileStatusLogResponse(
     val page: PageInfo,
     val fileStatus: List<FileStatusResponse>
 ) : RioResponse()
 
+@Serializable
 data class FileStatusResponse(
     val name: String,
+    @Serializable(with = URISerializer::class)
     val uri: URI,
     val sizeInBytes: Long,
     val status: String,
     val statusMessage: String,
     val lastUpdated: String,
+    @Serializable(with = UUIDSerializer::class)
     val foreignJob: UUID?
 ) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
@@ -5,18 +5,23 @@
  */
 package com.spectralogic.rioclient
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class LogsetResponse(
     val id: String,
     val status: String,
     val creationDate: String
 ) : RioResponse()
 
+@Serializable
 data class LogsetData(
     val id: String,
     val status: String,
     val creationDate: String
 )
 
+@Serializable
 data class LogsetListResponse(
     val logs: List<LogsetData>,
     val page: PageInfo

--- a/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
@@ -25,4 +25,4 @@ data class LogsetData(
 data class LogsetListResponse(
     val logs: List<LogsetData>,
     val page: PageInfo
-) : RioListResponse<LogsetData>(logs, page)
+) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Message.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Message.kt
@@ -58,4 +58,4 @@ data class MessageUpdateRequest(
 data class MessageListResponse(
     val data: List<MessageData>,
     val page: PageInfo
-) : RioListResponse<MessageData>(data, page)
+) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Message.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Message.kt
@@ -5,11 +5,15 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.UUID
 
+@Serializable
 data class MessageResponse(
-    @JsonProperty("id") val messageId: UUID,
+    @Serializable(with = UUIDSerializer::class)
+    @SerialName("id")
+    val messageId: UUID,
     val creationDate: String,
     val lastUpdated: String,
     val read: Boolean,
@@ -18,8 +22,11 @@ data class MessageResponse(
     val severity: String
 ) : RioResponse()
 
+@Serializable
 data class MessageData(
-    @JsonProperty("id") val messageId: UUID,
+    @SerialName("id")
+    @Serializable(with = UUIDSerializer::class)
+    val messageId: UUID,
     val creationDate: String,
     val lastUpdated: String,
     val read: Boolean,
@@ -28,22 +35,26 @@ data class MessageData(
     val severity: String
 )
 
+@Serializable
 data class MessageSubjectResponse(
     val key: String,
     val parameters: Map<String, String>?,
     val text: String
 ) : RioResponse()
 
+@Serializable
 data class MessageDetailsResponse(
     val key: String,
     val parameters: Map<String, String>?,
     val text: String
 ) : RioResponse()
 
+@Serializable
 data class MessageUpdateRequest(
     val read: Boolean
 ) : RioRequest
 
+@Serializable
 data class MessageListResponse(
     val data: List<MessageData>,
     val page: PageInfo

--- a/src/main/kotlin/com/spectralogic/rioclient/Restore.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Restore.kt
@@ -14,7 +14,6 @@ data class ByteRange(
     val endingIndex: Long
 )
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class RestoreRequest(
     val name: String? = null,

--- a/src/main/kotlin/com/spectralogic/rioclient/Restore.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Restore.kt
@@ -5,23 +5,27 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import kotlinx.serialization.Serializable
 import java.net.URI
 
+@Serializable
 data class ByteRange(
     val startingIndex: Long,
     val endingIndex: Long
 )
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class RestoreRequest(
     val name: String? = null,
     val files: List<FileToRestore>,
     val callbacks: List<JobCallback>? = null
 ) : RioRequest
 
+@Serializable
 data class FileToRestore(
     val name: String,
+    @Serializable(with = URISerializer::class)
     val uri: URI,
     val timeCodeRange: String? = null,
     val byteRange: ByteRange? = null

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -5,7 +5,6 @@
  */
 package com.spectralogic.rioclient
 
-
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
@@ -36,7 +35,6 @@ import io.ktor.http.isSuccess
 import io.ktor.http.withCharset
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.charsets.Charsets
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import nl.altindag.ssl.util.TrustManagerUtils
@@ -347,7 +345,7 @@ class RioClient(
         val paramMap: Map<String, Any?> = mapOf(
             Pair("index", index),
             Pair("re-index", reIndex),
-            Pair("overwrite-index", overWriteIndex),
+            Pair("overwrite-index", overWriteIndex)
         )
         return client.myPut("$api/brokers/$brokerName/agents/$agentName", paramMap = paramMap)
     }
@@ -403,10 +401,10 @@ class RioClient(
         internalMetadataValue: String? = null
     ): ObjectCountResponse {
         val paramMap: Map<String, Any?> = mapOf(
-                Pair("creation_date_start", dateStart),
-                Pair("creation_date_end", dateEnd),
-                Pair("prefix", prefix),
-                Pair("filename", filename)
+            Pair("creation_date_start", dateStart),
+            Pair("creation_date_end", dateEnd),
+            Pair("prefix", prefix),
+            Pair("filename", filename)
         ).let {
             if (!internalMetadataKey.isNullOrBlank() && !internalMetadataValue.isNullOrBlank()) {
                 it.plus(Pair("internalMetadata", "$internalMetadataKey,$internalMetadataValue"))
@@ -593,7 +591,7 @@ class RioClient(
     suspend fun clientDataUpdate(dataId: UUID, clientDataRequest: ClientDataRequest): ClientDataResponse =
         client.myPut("$api/system/clientData/$dataId", clientDataRequest)
     suspend fun clientDataDelete(dataId: UUID): EmptyResponse =
-        client.myDelete("$api/system/clientData/${dataId.toString()}")
+        client.myDelete("$api/system/clientData/$dataId")
     suspend fun clientDataList(
         clientDataId: String? = null,
         clientName: String? = null,
@@ -601,7 +599,7 @@ class RioClient(
         page: Long? = null,
         perPage: Long? = null,
         sortBy: String? = null,
-        sortOrder: String? = null,
+        sortOrder: String? = null
     ): ClientDataListResponse {
         val paramMap = pageParamMap(page, perPage)
             .plus(

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -37,6 +37,7 @@ import io.ktor.http.withCharset
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.charsets.Charsets
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import nl.altindag.ssl.util.TrustManagerUtils
 import java.io.Closeable
@@ -56,6 +57,7 @@ class RioClient(
         private val logger = mu.KotlinLogging.logger {}
     }
 
+    @Serializable
     private data class MyMetadata(val metadata: Map<String, String>) : RioRequest
     private val api by lazy { "$rioUrl/api" }
     private val tokenClient: TokenClient = TokenClient(rioUrl, username, password)
@@ -74,7 +76,6 @@ class RioClient(
             json(
                 Json {
                     ignoreUnknownKeys = true
-                    // TODO ?? isLenient = true
                 }
             )
         }

--- a/src/main/kotlin/com/spectralogic/rioclient/Serializers.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Serializers.kt
@@ -1,0 +1,98 @@
+package com.spectralogic.rioclient
+
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.util.UUID
+
+object HttpStatusCodeSerializer : KSerializer<HttpStatusCode> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("HttpStatusCode", PrimitiveKind.INT)
+
+    override fun deserialize(decoder: Decoder): HttpStatusCode {
+        return HttpStatusCode.fromValue(decoder.decodeInt())
+    }
+
+    override fun serialize(encoder: Encoder, value: HttpStatusCode) {
+        encoder.encodeInt(value.value)
+    }
+}
+
+object URISerializer : KSerializer<URI> {
+    override val descriptor = PrimitiveSerialDescriptor("URI", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): URI {
+        return URI(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: URI) {
+        encoder.encodeString(value.toString())
+    }
+}
+
+/*object URLSerializer : KSerializer<URL> {
+    override val descriptor = PrimitiveSerialDescriptor("URL", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): URL {
+        return URL(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: URL) {
+        encoder.encodeString(value.toString())
+    }
+}*/
+
+object UUIDSerializer : KSerializer<UUID> {
+    override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): UUID {
+        return UUID.fromString(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        encoder.encodeString(value.toString())
+    }
+}
+
+object RioResourceErrorMessageSerializer : KSerializer<RioResourceErrorMessage> {
+    override val descriptor = PrimitiveSerialDescriptor("RioResourceErrorMessage", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): RioResourceErrorMessage {
+        return Json.decodeFromString(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: RioResourceErrorMessage) {
+        encoder.encodeString(Json.encodeToString(value))
+    }
+}
+
+object RioValidationErrorMessageSerializer : KSerializer<RioValidationErrorMessage> {
+    override val descriptor = PrimitiveSerialDescriptor("RioValidationErrorMessage", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): RioValidationErrorMessage {
+        return Json.decodeFromString(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: RioValidationErrorMessage) {
+        encoder.encodeString(Json.encodeToString(value))
+    }
+}
+
+object RioUnsupportedMediaErrorSerializer : KSerializer<RioUnsupportedMediaErrorMessage> {
+    override val descriptor = PrimitiveSerialDescriptor("RioUnsupportedMediaError", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): RioUnsupportedMediaErrorMessage {
+        return Json.decodeFromString(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: RioUnsupportedMediaErrorMessage) {
+        encoder.encodeString(Json.encodeToString(value))
+    }
+}

--- a/src/main/kotlin/com/spectralogic/rioclient/Serializers.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Serializers.kt
@@ -2,14 +2,11 @@ package com.spectralogic.rioclient
 
 import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.Json
 import java.net.URI
 import java.util.UUID
 
@@ -37,18 +34,6 @@ object URISerializer : KSerializer<URI> {
     }
 }
 
-/*object URLSerializer : KSerializer<URL> {
-    override val descriptor = PrimitiveSerialDescriptor("URL", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): URL {
-        return URL(decoder.decodeString())
-    }
-
-    override fun serialize(encoder: Encoder, value: URL) {
-        encoder.encodeString(value.toString())
-    }
-}*/
-
 object UUIDSerializer : KSerializer<UUID> {
     override val descriptor = PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
 
@@ -58,41 +43,5 @@ object UUIDSerializer : KSerializer<UUID> {
 
     override fun serialize(encoder: Encoder, value: UUID) {
         encoder.encodeString(value.toString())
-    }
-}
-
-object RioResourceErrorMessageSerializer : KSerializer<RioResourceErrorMessage> {
-    override val descriptor = PrimitiveSerialDescriptor("RioResourceErrorMessage", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): RioResourceErrorMessage {
-        return Json.decodeFromString(decoder.decodeString())
-    }
-
-    override fun serialize(encoder: Encoder, value: RioResourceErrorMessage) {
-        encoder.encodeString(Json.encodeToString(value))
-    }
-}
-
-object RioValidationErrorMessageSerializer : KSerializer<RioValidationErrorMessage> {
-    override val descriptor = PrimitiveSerialDescriptor("RioValidationErrorMessage", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): RioValidationErrorMessage {
-        return Json.decodeFromString(decoder.decodeString())
-    }
-
-    override fun serialize(encoder: Encoder, value: RioValidationErrorMessage) {
-        encoder.encodeString(Json.encodeToString(value))
-    }
-}
-
-object RioUnsupportedMediaErrorSerializer : KSerializer<RioUnsupportedMediaErrorMessage> {
-    override val descriptor = PrimitiveSerialDescriptor("RioUnsupportedMediaError", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): RioUnsupportedMediaErrorMessage {
-        return Json.decodeFromString(decoder.decodeString())
-    }
-
-    override fun serialize(encoder: Encoder, value: RioUnsupportedMediaErrorMessage) {
-        encoder.encodeString(Json.encodeToString(value))
     }
 }

--- a/src/main/kotlin/com/spectralogic/rioclient/System.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/System.kt
@@ -5,8 +5,11 @@
  */
 package com.spectralogic.rioclient
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.util.UUID
 
+@Serializable
 data class SystemResponse(
     val version: String,
     val apiVersion: String,
@@ -18,11 +21,13 @@ data class SystemResponse(
     val buildType: String
 ) : RioResponse()
 
+@Serializable
 data class ServerData(
     val jvm: JvmData,
     val operatingSystem: OsData
 )
 
+@Serializable
 data class JvmData(
     val version: String,
     val vendor: String,
@@ -30,6 +35,7 @@ data class JvmData(
     val vmName: String
 )
 
+@Serializable
 data class OsData(
     val name: String,
     val arch: String,
@@ -37,6 +43,7 @@ data class OsData(
     val cores: Int
 )
 
+@Serializable
 data class ProcessStatsData(
     val uptime: Long,
     val totalMemory: Long,
@@ -44,6 +51,7 @@ data class ProcessStatsData(
     val freeMemory: Long
 )
 
+@Serializable
 data class ClientDataRequest(
     val clientDataId: String,
     val clientName: String,
@@ -51,7 +59,9 @@ data class ClientDataRequest(
     val mapData: Map<String, String>
 ) : RioRequest
 
+@Serializable
 data class ClientDataResponse(
+    @Serializable(with = UUIDSerializer::class)
     val dataId: UUID,
     val creationDate: String,
     val clientDataId: String,
@@ -60,12 +70,17 @@ data class ClientDataResponse(
     val mapData: Map<String, String>
 ) : RioResponse()
 
+@Serializable
 data class ClientDataListResponse(
+    @SerialName("result")
     val result: List<ClientData>,
+    @SerialName("page")
     val page: PageInfo
 ) : RioListResponse<ClientData>(result, page)
 
+@Serializable
 data class ClientData(
+    @Serializable(with = UUIDSerializer::class)
     val dataId: UUID,
     val creationDate: String,
     val clientDataId: String,

--- a/src/main/kotlin/com/spectralogic/rioclient/System.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/System.kt
@@ -72,11 +72,9 @@ data class ClientDataResponse(
 
 @Serializable
 data class ClientDataListResponse(
-    @SerialName("result")
     val result: List<ClientData>,
-    @SerialName("page")
     val page: PageInfo
-) : RioListResponse<ClientData>(result, page)
+) : RioResponse()
 
 @Serializable
 data class ClientData(

--- a/src/main/kotlin/com/spectralogic/rioclient/System.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/System.kt
@@ -5,7 +5,6 @@
  */
 package com.spectralogic.rioclient
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import java.util.UUID
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Token.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Token.kt
@@ -5,45 +5,55 @@
  */
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import kotlinx.serialization.Serializable
 import java.util.UUID
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+// @JsonInclude(JsonInclude.Include.NON_NULL)
+@Serializable
 data class TokenCreateRequest(
     val expirationDate: String? = null
 ) : RioRequest
 
+@Serializable
 data class TokenResponse(
     val token: String,
     val expirationDate: String?,
     val creationDate: String,
     val userName: String,
+    @Serializable(with = UUIDSerializer::class)
     val id: UUID
 ) : RioResponse()
 
+@Serializable
 open class TokenKeyResponse(
     val expirationDate: String? = null,
     val creationDate: String,
     val userName: String,
+    @Serializable(with = UUIDSerializer::class)
     val id: UUID
 ) : RioResponse()
 
+@Serializable
 open class TokenKeyData(
     val expirationDate: String? = null,
     val creationDate: String,
     val userName: String,
+    @Serializable(with = UUIDSerializer::class)
     val id: UUID
 )
 
+@Serializable
 open class ShortTokenResponse(
     val token: String
 ) : RioResponse()
 
+@Serializable
 data class TokenListResponse(
     val data: List<TokenKeyData>,
     val page: PageInfo
 ) : RioListResponse<TokenKeyData>(data, page)
 
+@Serializable
 data class UserLoginCredentials(
     val username: String,
     val password: String

--- a/src/main/kotlin/com/spectralogic/rioclient/Token.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Token.kt
@@ -8,7 +8,6 @@ package com.spectralogic.rioclient
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
-// @JsonInclude(JsonInclude.Include.NON_NULL)
 @Serializable
 data class TokenCreateRequest(
     val expirationDate: String? = null
@@ -51,7 +50,7 @@ open class ShortTokenResponse(
 data class TokenListResponse(
     val data: List<TokenKeyData>,
     val page: PageInfo
-) : RioListResponse<TokenKeyData>(data, page)
+) : RioResponse()
 
 @Serializable
 data class UserLoginCredentials(

--- a/src/main/kotlin/com/spectralogic/rioclient/Token.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Token.kt
@@ -16,7 +16,7 @@ data class TokenCreateRequest(
 @Serializable
 data class TokenResponse(
     val token: String,
-    val expirationDate: String?,
+    val expirationDate: String? = null,
     val creationDate: String,
     val userName: String,
     @Serializable(with = UUIDSerializer::class)

--- a/src/main/kotlin/com/spectralogic/rioclient/TokenClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/TokenClient.kt
@@ -1,6 +1,5 @@
 package com.spectralogic.rioclient
 
-
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
@@ -20,9 +19,11 @@ internal class TokenClient(private val endpoint: URL, private val username: Stri
 
     private val client = HttpClient(CIO) {
         install(ContentNegotiation) {
-            json(Json{
-                ignoreUnknownKeys = true
-            })
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                }
+            )
         }
         engine {
             https {

--- a/src/main/kotlin/com/spectralogic/rioclient/TokenClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/TokenClient.kt
@@ -1,16 +1,17 @@
 package com.spectralogic.rioclient
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
-import io.ktor.client.features.json.JacksonSerializer
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.logging.Logging
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
 import nl.altindag.ssl.util.TrustManagerUtils
 import java.net.URL
 
@@ -18,15 +19,10 @@ internal class TokenClient(private val endpoint: URL, private val username: Stri
     private val api by lazy { "$endpoint/api" }
 
     private val client = HttpClient(CIO) {
-        install(JsonFeature) {
-            acceptContentTypes = listOf(ContentType.Application.Json, ContentType("text", "json"))
-            serializer = JacksonSerializer {
-                registerModule(KotlinModule.Builder().build())
-                registerModule(JavaTimeModule())
-                configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
-                configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true)
-            }
+        install(ContentNegotiation) {
+            json(Json{
+                ignoreUnknownKeys = true
+            })
         }
         engine {
             https {
@@ -39,8 +35,8 @@ internal class TokenClient(private val endpoint: URL, private val username: Stri
     suspend fun getShortToken(): String {
         val response: ShortTokenResponse = client.post("$api/tokens") {
             contentType(ContentType.Application.Json)
-            body = UserLoginCredentials(username, password)
-        }
+            setBody(UserLoginCredentials(username, password))
+        }.body()
         return response.token
     }
 }

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -466,7 +466,6 @@ class RioClient_Test {
 
     @Test
     fun endPointTest(@TempDir uriDir: Path) = blockingTest {
-
         val ftpName = "ftp-${uuid()}"
         val ftpRequest = FtpEndpointDeviceCreateRequest(ftpName, "ftp://ftp.test.com", "user", "pass")
         val ftpResponse = rioClient.createFtpEndpointDevice(ftpRequest)
@@ -624,7 +623,7 @@ class RioClient_Test {
                 archiveJobName,
                 listOf(
                     FileToArchive(uuid(), URI("aToZSequence://file"), 1024L, metadata),
-                    FileToArchive(uuid(), URI("aToZSequence://file"), 2048L, metadata),
+                    FileToArchive(uuid(), URI("aToZSequence://file"), 2048L, metadata)
                 )
             )
             val archiveJob = rioClient.createArchiveJob(testBroker, archiveRequest)
@@ -732,7 +731,7 @@ class RioClient_Test {
                 archiveJobName,
                 listOf(
                     FileToArchive(uuid(), URI("aToZSequence://file"), 1024L, metadata),
-                    FileToArchive(uuid(), URI("aToZSequence://file"), 2048L, metadata),
+                    FileToArchive(uuid(), URI("aToZSequence://file"), 2048L, metadata)
                 ),
                 jobMetadata,
                 archiveJobCallbacks
@@ -1010,7 +1009,6 @@ class RioClient_Test {
 
     @Test
     fun logTest() = blockingTest {
-
         var listLogs = rioClient.listLogsets()
         val totalLogs = listLogs.page.totalItems
 
@@ -1141,7 +1139,7 @@ class RioClient_Test {
         }.toMap()
         val updatedItem = rioClient.clientDataUpdate(
             getItem.dataId,
-            ClientDataRequest("123", "456","789", updateMapData)
+            ClientDataRequest("123", "456", "789", updateMapData)
         )
         assertThat(updatedItem.statusCode).describedAs(cdtDescFmt.format(++testNum)).isEqualTo(HttpStatusCode.OK)
         assertThat(updatedItem.dataId).describedAs(cdtDescFmt.format(++testNum)).isEqualTo(getItem.dataId)

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -533,7 +533,7 @@ class RioClient_Test {
             removeBroker()
 
             val agentConfig = BpAgentConfig(brokerBucket, spectraDeviceCreateRequest.name, spectraDeviceCreateRequest.username)
-            val createRequest = BrokerCreateRequest(testBroker, testAgent, agentConfig)
+            val createRequest = BrokerCreateRequest(testBroker, testAgent, agentConfig.toConfigMap())
 
             val createBroker = rioClient.createBroker(createRequest)
             assertThat(createBroker.statusCode).isEqualTo(HttpStatusCode.Created)
@@ -915,7 +915,7 @@ class RioClient_Test {
         try {
             if (!rioClient.headBroker(objectBroker)) {
                 val agentConfig = BpAgentConfig(brokerObjectBucket, spectraDeviceCreateRequest.name, spectraDeviceCreateRequest.username)
-                val createRequest = BrokerCreateRequest(objectBroker, "agent-name", agentConfig)
+                val createRequest = BrokerCreateRequest(objectBroker, "agent-name", agentConfig.toConfigMap())
                 val createResponse = rioClient.createBroker(createRequest)
                 assertThat(createResponse.statusCode).isEqualTo(HttpStatusCode.Created)
             }
@@ -1221,7 +1221,7 @@ class RioClient_Test {
     private suspend fun ensureBrokerExists() {
         if (!rioClient.headBroker(testBroker)) {
             val agentConfig = BpAgentConfig(brokerBucket, spectraDeviceCreateRequest.name, spectraDeviceCreateRequest.username)
-            val createRequest = BrokerCreateRequest(testBroker, testAgent, agentConfig)
+            val createRequest = BrokerCreateRequest(testBroker, testAgent, agentConfig.toConfigMap())
             val createResponse = rioClient.createBroker(createRequest)
             assertThat(createResponse.statusCode).isEqualTo(HttpStatusCode.Created)
         }


### PR DESCRIPTION
Needless to say, this is not trivial!

There are breaking changes to the API, so the version has been bumped from 1.2.1 to 2.0.0

Changed from Jackson serialization to Kotlinx.serialization, mostly just adding @Serialization annotation
  - Added deserializers for UUID, URI, and HttpStatusCode
  - Jackson: @JsonInclude(JsonInclude.Include.NON_NULL) replaced by assigning a default value of null
Refactor response objects from implementing a parent class to be self contained and implementing RioReponse
Removed RioListResponse and refactored all implementers to be self contained and implementing RioReponse
Refactor RioHttpException:
  - Ktor client no longer throws exception on non 200 status
  - RioBroker error response isolation
Align data object field names to match JSON payload
  - FileStatus
Annotate where needed when default field value should be part of payload
Refactor CreateBrokerRequest to use Map