### PR TITLE
ESCP-3869: restore generic list which RioCruise uses in pageToFlow()

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -49,8 +49,8 @@ data class BpAgentConfig(
     val dataPolicyUUID: UUID? = null,
     @EncodeDefault val https: Boolean = false
 ) : AgentConfig() {
-    override fun toConfigMap(): Map<String, String> {
-        return buildMap(5) {
+    override fun toConfigMap(): Map<String, String> =
+        buildMap {
             put("bucket", bucket)
             put("blackPearlName", blackPearlName)
             put("username", username)
@@ -58,7 +58,6 @@ data class BpAgentConfig(
             put("https", https.toString())
             if (dataPolicyUUID != null) put("dataPolicyUUID", dataPolicyUUID.toString())
         }
-    }
 }
 
 @Serializable
@@ -66,12 +65,11 @@ data class VailAgentConfig(
     val vailDeviceName: String,
     val bucket: String
 ) : AgentConfig() {
-    override fun toConfigMap(): Map<String, String> {
-        return buildMap {
+    override fun toConfigMap(): Map<String, String> =
+        buildMap {
             put("vailDeviceName", vailDeviceName)
             put("bucket", bucket)
         }
-    }
 }
 
 @Serializable
@@ -81,14 +79,13 @@ data class DivaAgentConfig(
     val qos: Int?,
     val priority: Int?
 ) : AgentConfig() {
-    override fun toConfigMap(): Map<String, String> {
-        return buildMap {
+    override fun toConfigMap(): Map<String, String> =
+        buildMap {
             put("divaDeviceName", divaDeviceName)
             put("category", category)
             if (qos != null) put("qos", qos.toString())
             if (priority != null) put("priority", priority.toString())
         }
-    }
 }
 
 @Serializable
@@ -97,13 +94,12 @@ data class FlashnetAgentConfig(
     val applicationName: String,
     val storageGroupName: String
 ) : AgentConfig() {
-    override fun toConfigMap(): Map<String, String> {
-        return buildMap {
+    override fun toConfigMap(): Map<String, String> =
+        buildMap {
             put("flashnetDeviceName", flashnetDeviceName)
             put("applicationName", applicationName)
             put("storageGroupName", storageGroupName)
         }
-    }
 }
 
 @Serializable
@@ -112,13 +108,12 @@ data class SglLtfsAgentConfig(
     val blackPearlName: String,
     val username: String
 ) : AgentConfig() {
-    override fun toConfigMap(): Map<String, String> {
-        return buildMap {
+    override fun toConfigMap(): Map<String, String> =
+        buildMap {
             put("bucket", bucket)
             put("blackPearlName", blackPearlName)
             put("username", username)
         }
-    }
 }
 
 @Serializable
@@ -195,7 +190,10 @@ data class Checksum(val hash: String, val type: String)
 data class ObjectListResponse(
     val objects: List<ObjectData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<ObjectData> {
+    override fun page() = page
+    override fun results() = objects
+}
 
 @Serializable
 data class ObjectCountResponse(
@@ -222,10 +220,16 @@ data class ObjectHeadData(
 data class BrokerListResponse(
     val brokers: List<BrokerData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<BrokerData> {
+    override fun page()= page
+    override fun results() = brokers
+}
 
 @Serializable
 data class AgentListResponse(
     val agents: List<AgentData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<AgentData> {
+    override fun page() = page
+    override fun results() = agents
+}

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -221,7 +221,7 @@ data class BrokerListResponse(
     val brokers: List<BrokerData>,
     val page: PageInfo
 ) : RioResponse(), RioListResponse<BrokerData> {
-    override fun page()= page
+    override fun page() = page
     override fun results() = brokers
 }
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
@@ -15,7 +15,13 @@ data class ClusterResponse(
 @Serializable
 data class ClusterMembersListResponse(
     val clusterMembers: List<ClusterMemberData>
-) : RioResponse()
+) : RioResponse(), RioListResponse<ClusterMemberData> {
+    override fun page(): PageInfo {
+        val count = clusterMembers.size.toLong()
+        return PageInfo(count, count, 1L, count)
+    }
+    override fun results() = clusterMembers
+}
 
 @Serializable
 data class ClusterMemberResponse(

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -45,7 +45,10 @@ data class SpectraDeviceData(
 data class SpectraDeviceListResponse(
     val devices: List<SpectraDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<SpectraDeviceData> {
+    override fun page() = page
+    override fun results()= devices
+}
 
 @Serializable
 data class DivaDeviceCreateRequest(
@@ -80,7 +83,10 @@ data class DivaDeviceData(
 data class DivaDeviceListResponse(
     val devices: List<DivaDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<DivaDeviceData> {
+    override fun page() = page
+    override fun results() = devices
+}
 
 @Serializable
 data class FlashnetDeviceCreateRequest(
@@ -147,7 +153,10 @@ data class FlashnetDeviceDatabaseData(
 data class FlashnetDeviceListResponse(
     val devices: List<FlashnetDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<FlashnetDeviceData> {
+    override fun page() = page
+    override fun results() = devices
+}
 
 @Serializable
 data class TbpfrDeviceCreateRequest(
@@ -182,7 +191,10 @@ data class TbpfrDeviceData(
 data class TbpfrDeviceListResponse(
     val devices: List<TbpfrDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<TbpfrDeviceData> {
+    override fun page() = page
+    override fun results() = devices
+}
 
 @Serializable
 data class VailDeviceCreateRequest(
@@ -225,10 +237,19 @@ data class VailDeviceData(
 data class VailDeviceListResponse(
     val devices: List<VailDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<VailDeviceData> {
+    override fun page() = page
+    override fun results() = devices
+}
 
 @Serializable
 data class DeviceObjectListResponse(
     val objects: List<String>,
     val isTruncated: Boolean
-) : RioResponse()
+) : RioResponse(), RioListResponse<String> {
+    override fun page(): PageInfo {
+        val count = objects.size.toLong()
+        return PageInfo(count, count, 1L, count)
+    }
+    override fun results() = objects
+}

--- a/src/main/kotlin/com/spectralogic/rioclient/Device.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Device.kt
@@ -47,7 +47,7 @@ data class SpectraDeviceListResponse(
     val page: PageInfo
 ) : RioResponse(), RioListResponse<SpectraDeviceData> {
     override fun page() = page
-    override fun results()= devices
+    override fun results() = devices
 }
 
 @Serializable

--- a/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Endpoint.kt
@@ -47,7 +47,10 @@ data class UriEndpointDeviceCreateRequest(
 data class EndpointDeviceListResponse(
     val devices: List<EndpointGenericDeviceData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<EndpointGenericDeviceData> {
+    override fun page() = page
+    override fun results() = devices
+}
 
 interface EndpointDeviceResponse {
     val name: String

--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -19,6 +19,11 @@ open class RioResponse {
     var statusCode = HttpStatusCode.Processing
 }
 
+interface RioListResponse<T> {
+    fun page(): PageInfo
+    fun results(): List<T>
+}
+
 @Serializable
 class EmptyResponse : RioResponse()
 

--- a/src/main/kotlin/com/spectralogic/rioclient/Job.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Job.kt
@@ -95,7 +95,10 @@ data class ForeignJobDetails(
 data class JobListResponse(
     val jobs: List<JobData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<JobData> {
+    override fun page() = page
+    override fun results() = jobs
+}
 
 @Serializable
 data class FileStatus(

--- a/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Logset.kt
@@ -25,4 +25,7 @@ data class LogsetData(
 data class LogsetListResponse(
     val logs: List<LogsetData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<LogsetData> {
+    override fun page() = page
+    override fun results() = logs
+}

--- a/src/main/kotlin/com/spectralogic/rioclient/Message.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Message.kt
@@ -58,4 +58,7 @@ data class MessageUpdateRequest(
 data class MessageListResponse(
     val data: List<MessageData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<MessageData> {
+    override fun page() = page
+    override fun results() = data
+}

--- a/src/main/kotlin/com/spectralogic/rioclient/System.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/System.kt
@@ -73,7 +73,10 @@ data class ClientDataResponse(
 data class ClientDataListResponse(
     val result: List<ClientData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<ClientData> {
+    override fun page() = page
+    override fun results() = result
+}
 
 @Serializable
 data class ClientData(

--- a/src/main/kotlin/com/spectralogic/rioclient/Token.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Token.kt
@@ -50,7 +50,10 @@ open class ShortTokenResponse(
 data class TokenListResponse(
     val data: List<TokenKeyData>,
     val page: PageInfo
-) : RioResponse()
+) : RioResponse(), RioListResponse<TokenKeyData> {
+    override fun page() = page
+    override fun results() = data
+}
 
 @Serializable
 data class UserLoginCredentials(

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -481,7 +481,7 @@ class RioClient_Test {
         assertThat(endpointsResponse.statusCode).isEqualTo(HttpStatusCode.OK)
 
         assertRioListResponse("endpoints", endpointsResponse.page.totalItems) { page, perPage ->
-                rioClient.listEndpointDevices(page, perPage)
+            rioClient.listEndpointDevices(page, perPage)
         }
 
         val ftpResponse = rioClient.createFtpEndpointDevice(ftpRequest)

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -111,6 +111,10 @@ class RioClient_Test {
         assertThat(listResponse.devices.map { it.name }).contains(spectraDeviceName)
         assertThat(spectraDeviceTotal).isGreaterThanOrEqualTo(2)
 
+        assertRioListResponse("spectra devices", listResponse.page.totalItems) { page, perPage ->
+            rioClient.listSpectraDevices(page, perPage)
+        }
+
         assertThat(rioClient.headSpectraDevice(spectraDeviceName)).isTrue
         assertThat(rioClient.headDevice("spectra", spectraDeviceName)).isTrue
 
@@ -296,6 +300,10 @@ class RioClient_Test {
             assertThat(listResponse.statusCode).isEqualTo(HttpStatusCode.OK)
             val totalDivaDevices = listResponse.page.totalItems
 
+            assertRioListResponse("diva devices", totalDivaDevices) { page, perPage ->
+                rioClient.listDivaDevices(page, perPage)
+            }
+
             val createRequest = DivaDeviceCreateRequest(divaDeviceName, divaEndpoint, divaUsername, divaPassword)
             val createResponse = rioClient.createDivaDevice(createRequest)
             assertThat(createResponse.statusCode).isEqualTo(HttpStatusCode.Created)
@@ -468,6 +476,14 @@ class RioClient_Test {
     fun endPointTest(@TempDir uriDir: Path) = blockingTest {
         val ftpName = "ftp-${uuid()}"
         val ftpRequest = FtpEndpointDeviceCreateRequest(ftpName, "ftp://ftp.test.com", "user", "pass")
+
+        val endpointsResponse = rioClient.listEndpointDevices()
+        assertThat(endpointsResponse.statusCode).isEqualTo(HttpStatusCode.OK)
+
+        assertRioListResponse("endpoints", endpointsResponse.page.totalItems) { page, perPage ->
+                rioClient.listEndpointDevices(page, perPage)
+        }
+
         val ftpResponse = rioClient.createFtpEndpointDevice(ftpRequest)
         assertThat(ftpResponse.statusCode).isEqualTo(HttpStatusCode.Created)
         assertThat(ftpResponse.name).isEqualTo(ftpName)
@@ -547,6 +563,10 @@ class RioClient_Test {
             assertThat(listBrokers.brokers).isNotEmpty
             assertThat(listBrokers.brokers.map { it.name }).contains(testBroker)
 
+            assertRioListResponse("brokers", listBrokers.page.totalItems) { page, perPage ->
+                rioClient.listBrokers(page, perPage)
+            }
+
             var getWriteAgent = rioClient.getAgent(testBroker, testAgent)
             assertThat(getWriteAgent.statusCode).isEqualTo(HttpStatusCode.OK)
             assertThat(getWriteAgent.name).isEqualTo(testAgent)
@@ -558,6 +578,10 @@ class RioClient_Test {
             assertThat(listAgents.statusCode).isEqualTo(HttpStatusCode.OK)
             assertThat(listAgents.agents).hasSize(1)
             assertThat(listAgents.agents.first().name).isEqualTo(getWriteAgent.name)
+
+            assertRioListResponse("agents", listAgents.page.totalItems) { page, perPage ->
+                rioClient.listAgents(testBroker, page, perPage)
+            }
 
             val mapEntry = Pair("username", spectraDeviceAltUsername)
             val updateRequest = AgentUpdateRequest(mapOf(mapEntry))
@@ -695,6 +719,10 @@ class RioClient_Test {
             assertThat(jobList.jobs.map { it.id }).contains(archiveJob.id)
             assertThat(jobList.jobs.map { it.id }).contains(restoreJob.id)
 
+            assertRioListResponse("completed jobs", jobList.page.totalItems) { page, perPage ->
+                rioClient.listJobs(broker = testBroker, jobStatus = "COMPLETED", page = page, perPage = perPage)
+            }
+
             val totalJobs = jobList.page.totalItems
             val deleteArchiveJobResponse = rioClient.deleteJob(archiveJob.id)
             assertThat(deleteArchiveJobResponse.statusCode).isEqualTo(HttpStatusCode.NoContent)
@@ -809,6 +837,10 @@ class RioClient_Test {
 
             var listObjects = rioClient.listObjects(testBroker)
             val totalObjects = listObjects.page.totalItems
+
+            assertRioListResponse("objects", listObjects.page.totalItems) { page, perPage ->
+                rioClient.listObjects(brokerName = testBroker, page = page, perPage = perPage)
+            }
 
             var countResponse = rioClient.objectCount(testBroker)
             assertThat(countResponse.statusCode).isEqualTo(HttpStatusCode.OK)
@@ -1031,6 +1063,10 @@ class RioClient_Test {
         assertThat(listLogs.page.totalItems).isEqualTo(totalLogs + 1)
         assertThat(listLogs.logs.map { it.id }).contains(newLog.id)
 
+        assertRioListResponse("logsets", listLogs.page.totalItems) { page, perPage ->
+            rioClient.listLogsets(page, perPage)
+        }
+
         val deleteLogSetResponse = rioClient.deleteLogset(UUID.fromString(newLog.id))
         assertThat(deleteLogSetResponse.statusCode).isEqualTo(HttpStatusCode.NoContent)
         assertThat(rioClient.headLogset(UUID.fromString(newLog.id))).isFalse
@@ -1171,6 +1207,10 @@ class RioClient_Test {
         var listTokens = rioClient.listTokenKeys()
         val totalTokens = listTokens.page.totalItems
 
+        assertRioListResponse("tokens", listTokens.page.totalItems) { page, perPage ->
+            rioClient.listTokenKeys(page, perPage)
+        }
+
         val createToken = rioClient.createApiToken(TokenCreateRequest())
         assertThat(createToken.statusCode).isEqualTo(HttpStatusCode.Created)
         assertThat(createToken.userName).isEqualTo(username)
@@ -1264,3 +1304,15 @@ class RioClient_Test {
 
 private fun getenvValue(key: String, default: String): String =
     System.getenv(key) ?: default
+
+private fun <T> assertRioListResponse(desc: String, assertCount: Long, fn: suspend (pageNumber: Long, perPage: Long) -> RioListResponse<T>) {
+    val firstPage = runBlocking { fn(0L, 3L) }
+    assertThat(firstPage.page().totalItems).describedAs(desc).isEqualTo(assertCount)
+    var count = firstPage.results().size
+    (1L until firstPage.page().totalPages).forEach { num ->
+        val nextPage = runBlocking { fn(num, 3L) }
+        assertThat(nextPage.page().totalItems).describedAs(desc).isEqualTo(assertCount)
+        count += nextPage.results().size
+    }
+    assertThat(count.toLong()).describedAs(desc).isEqualTo(assertCount)
+}


### PR DESCRIPTION
 ... and clean up Broker agent toConfigMap()