### PR TITLE
ESCP-3894: Constants for job and file status

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.spectralogic.rio"
-version = "2.0.1"
+version = "2.0.2"
 
 tasks {
     withType<JavaCompile> {

--- a/src/main/kotlin/com/spectralogic/rioclient/Job.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Job.kt
@@ -10,6 +10,45 @@ import java.net.URI
 import java.util.Collections.emptyMap
 import java.util.UUID
 
+enum class JobStatusEnum(val isFinal: Boolean = false) {
+    ACTIVE,
+    COMPLETED(true),
+    CANCELED(true),
+    ERROR(true),
+    UNKNOWN;
+
+    companion object {
+        fun parse(status: String): JobStatusEnum {
+            return try {
+                JobStatusEnum.valueOf(status)
+            } catch (_: IllegalArgumentException ) {
+                UNKNOWN
+            }
+        }
+    }
+}
+
+enum class FileStatusEnum(val isFinal: Boolean = false) {
+    Completed(true),
+    Error(true),
+    Initializing,
+    Indexing,
+    Copying,
+    Transferring,
+    Rewrapping,
+    UNKNOWN;
+
+    companion object {
+        fun parse(status: String): FileStatusEnum {
+            return try {
+                FileStatusEnum.valueOf(status)
+            } catch (_: IllegalArgumentException ) {
+                UNKNOWN
+            }
+        }
+    }
+}
+
 @Serializable
 data class JobStatus(
     val message: String,


### PR DESCRIPTION
We'll have to refactor RC and Ipanema to use.

There may be a RC bug here:
https://github.com/SpectraLogic/rio_cruise/blob/68cf6822ded733d1da2076fbca919bde9df606ba/src/main/kotlin/com/spectralogic/rioCruise/service/webhook/timer/CoroutineOrphanTimer.kt#L52