### PR TITLE
Upgrade to Ktor 2.2.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:1.8.0"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.2")
 
-    val ktorVersion = "2.2.1"
+    val ktorVersion = "2.2.4"
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-client-cio:$ktorVersion")
     implementation("io.ktor:ktor-client-json:$ktorVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.spectralogic.rio"
-version = "2.0.2"
+version = "2.0.3"
 
 tasks {
     withType<JavaCompile> {

--- a/src/main/kotlin/com/spectralogic/rioclient/General.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/General.kt
@@ -10,8 +10,18 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonClassDiscriminator
 
-interface RioRequest
+
+const val RioRequestDiscriminator = "rio_request_type"
+@Serializable
+@JsonClassDiscriminator(RioRequestDiscriminator)
+sealed interface RioRequest
+
+@Serializable
+data class RioEmptyRequest(
+    val contentLength: Long = 0
+) : RioRequest
 
 @Serializable
 open class RioResponse {


### PR DESCRIPTION
1. Remove attempt to serialize Any by using RioEmptyRequest object
2. Change polymorphism discriminator from "type" to "rio_request_type" to avoid conflict with "type" in RioBroker endpoint requests
3. Suppress discriminator from being included in the request payload

This does not need to be cherry picked to RioClient 1.x