### PR TITLE
Fix cluster APIs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.spectralogic.rio"
-version = "2.0.5"
+version = "2.0.6"
 
 dependencies {
     implementation(platform(libs.kotlinBom))

--- a/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Cluster.kt
@@ -14,13 +14,13 @@ data class ClusterResponse(
 
 @Serializable
 data class ClusterMembersListResponse(
-    val clusterMembers: List<ClusterMemberData>
+    val members: List<ClusterMemberData>
 ) : RioResponse(), RioListResponse<ClusterMemberData> {
     override fun page(): PageInfo {
-        val count = clusterMembers.size.toLong()
-        return PageInfo(count, count, 1L, count)
+        val count = members.size.toLong()
+        return PageInfo(0, count, 1L, count)
     }
-    override fun results() = clusterMembers
+    override fun results() = members
 }
 
 @Serializable

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -126,13 +126,13 @@ class RioClient(
         client.myPost("$api/cluster", paramMap = paramMap("cluster_url", url))
 
     suspend fun getCluster(): ClusterResponse =
-        client.myPost("$api/cluster")
+        client.myGet("$api/cluster")
 
     suspend fun deleteCluster(): EmptyResponse =
         client.myPost("$api/cluster")
 
     suspend fun listClusterMembers(): ClusterMembersListResponse =
-        client.myGet("$api/cluster/members/")
+        client.myGet("$api/cluster/members")
 
     /**
      * Device

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -1286,6 +1286,30 @@ class RioClient_Test {
         // TODO: keys unhappy path testing
     }
 
+    @Test
+    fun clusterTest() = blockingTest {
+        val resp = rioClient.getCluster()
+        assertThat(resp.statusCode).isEqualTo(HttpStatusCode.OK)
+        assertThat(resp.clusterName).isNotNull.isNotBlank
+
+        val listResponse = rioClient.listClusterMembers()
+        assertThat(listResponse.statusCode).isEqualTo(HttpStatusCode.OK)
+        assertThat(listResponse.members).isNotEmpty
+        listResponse.members.first().let { member ->
+            assertThat(member.memberId).isNotBlank
+            assertThat(member.clusterPort).isGreaterThan(0)
+            assertThat(member.httpPort).isGreaterThan(0)
+            assertThat(member.role).isNotBlank
+            assertThat(member.ipAddress).isNotBlank
+        }
+        listResponse.page().let { page ->
+            assertThat(page.number).isEqualTo(0L)
+            assertThat(page.pageSize).isEqualTo(listResponse.members.size.toLong())
+            assertThat(page.totalPages).isEqualTo(1L)
+            assertThat(page.totalItems).isEqualTo(listResponse.members.size.toLong())
+        }
+    }
+
     private suspend fun ensureBrokerExists() {
         if (!rioClient.headBroker(testBroker)) {
             val agentConfig = BpAgentConfig(brokerBucket, spectraDeviceCreateRequest.name, spectraDeviceCreateRequest.username)


### PR DESCRIPTION
For Rio Watch Folders I want to test a Rio connection using systemInfo() for an non-authorized test and getCluster() for an authorized test.   This has identified a number of issues with RioClient for these rarely/non used APIs which I am now fixing.

