### PR TITLE
Rio client registration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.spectralogic.rio"
-version = "3.0.2"
+version = "3.0.3"
 
 dependencies {
     implementation(platform(libs.kotlinBom))

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -731,7 +731,7 @@ class RioClient(
     /**
      * Private worker methods
      */
-    
+
     private fun Map<String, Any?>?.queryString(): String =
         this?.let {
             "?" + it.map { (k, v) ->

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -671,6 +671,18 @@ class RioClient(
         return client.myPost("$api/system/rioclient", request)
     }
 
+    suspend fun saveRioClientSilent(
+        application: String,
+        version: String,
+        port: Int,
+        urlPath: String,
+        https: Boolean = false
+    ) {
+        withContext(Dispatchers.IO) {
+            saveRioClient(application, version, port, urlPath, https)
+        }
+    }
+
     suspend fun listRioClients(
         application: String? = null,
         page: Long? = null,

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -731,11 +731,7 @@ class RioClient(
     /**
      * Private worker methods
      */
-
-    /**
-     * Private worker methods
-     */
-
+    
     private fun Map<String, Any?>?.queryString(): String =
         this?.let {
             "?" + it.map { (k, v) ->

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -36,6 +36,8 @@ import io.ktor.http.withCharset
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.charsets.Charsets
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -678,8 +680,10 @@ class RioClient(
         urlPath: String,
         https: Boolean = false
     ) {
-        withContext(Dispatchers.IO) {
-            saveRioClient(application, version, port, urlPath, https)
+        coroutineScope {
+            launch {
+                saveRioClient(application, version, port, urlPath, https)
+            }
         }
     }
 
@@ -723,6 +727,10 @@ class RioClient(
     override fun close() {
         client.close()
     }
+
+    /**
+     * Private worker methods
+     */
 
     /**
      * Private worker methods

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClient_Test.kt
@@ -1261,7 +1261,7 @@ class RioClient_Test {
         val appName = "rio client test $uuid"
         var testNum = 0
         val testDesc = "RegisterClientTest %d"
-        val rc1 = rioClient.saveRioClient(appName,"1.2.3", 9999, "/app", true).let { resp ->
+        val rc1 = rioClient.saveRioClient(appName, "1.2.3", 9999, "/app", true).let { resp ->
             assertThat(resp.statusCode).describedAs(testDesc.format(++testNum)).isEqualTo(HttpStatusCode.Created)
             assertThat(resp.application).describedAs(testDesc.format(++testNum)).isEqualTo(appName)
             assertThat(resp.version).describedAs(testDesc.format(++testNum)).isEqualTo("1.2.3")
@@ -1284,7 +1284,6 @@ class RioClient_Test {
         rioClient.listRioClients(appName).let { resp ->
             assertThat(resp.statusCode).describedAs(testDesc.format(++testNum)).isEqualTo(HttpStatusCode.OK)
             assertThat(resp.page.totalItems).describedAs(testDesc.format(++testNum)).isEqualTo(1)
-
         }
         rioClient.updateRioClient(
             rc1.id,
@@ -1303,7 +1302,7 @@ class RioClient_Test {
             assertThat(resp.fqdnUrl).describedAs(testDesc.format(++testNum)).isEqualTo("https://host.domain.com:2020/api")
         }
         delay(1500)
-        rioClient.saveRioClient(appName,"3.2.1", 9999, "/app", true).let { resp ->
+        rioClient.saveRioClient(appName, "3.2.1", 9999, "/app", true).let { resp ->
             assertThat(resp.statusCode).describedAs(testDesc.format(++testNum)).isEqualTo(HttpStatusCode.Created)
             assertThat(resp.application).describedAs(testDesc.format(++testNum)).isEqualTo(rc1.application)
             assertThat(resp.macAddress).describedAs(testDesc.format(++testNum)).isEqualTo(rc1.macAddress)


### PR DESCRIPTION
@scribe will this do what I am hoping it will?

The network lookups for IP and FQDM are taking 5-6 seconds on my machine.  WatchFolders does not care about the response so I added saveRioClientSilent() hoping to allow WF to move on without waiting for results.