### PR TITLE
ESCP-4944: Life cycle policy APIs and start of tests.

### DIFF
--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -144,6 +144,7 @@ data class NasAgentConfig(
 data class AgentCreateRequest(
     val name: String,
     val type: String,
+    val writable: Boolean,
     val agentConfig: Map<String, String>,
 ) : RioRequest
 
@@ -159,6 +160,7 @@ data class AgentResponse(
     val creationDate: String,
     val lastIndexDate: String? = null,
     val writable: Boolean,
+    val archiveAgent: Boolean,
     val agentConfig: Map<String, String>,
     val indexState: String? = null,
 ) : RioResponse()
@@ -170,6 +172,7 @@ data class AgentData(
     val creationDate: String,
     val lastIndexDate: String? = null,
     val writable: Boolean,
+    val archiveAgent: Boolean,
     val agentConfig: Map<String, String>,
     val indexState: String? = null,
 )
@@ -306,3 +309,24 @@ data class DailyPeakHoursResponse(
     val endMinuteOfDay: Int,
 ) : RioResponse()
 
+@Serializable
+data class LifeCycleRequest(
+    val name: String,
+    val deferDays: Int,
+    val deleteDays: Int,
+) : RioRequest
+
+@Serializable
+data class LifeCycleResponse(
+    val name: String,
+    val uuid: String,
+    val deferDays: Int,
+    val deleteDays: Int,
+    val brokersUsing: List<String>? = null,
+) : RioResponse()
+
+@Serializable
+data class ListLifeCycleResponse(
+    val page: PageInfo,
+    val lifeCycles: List<LifeCycleResponse>,
+) : RioResponse()

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -132,7 +132,7 @@ data class SglLtfsAgentConfig(
 
 @Serializable
 data class NasAgentConfig(
-    val uri: String
+    val uri: String,
 ) : AgentConfig() {
     override fun toConfigMap(): Map<String, String> =
         buildMap {

--- a/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/Broker.kt
@@ -266,3 +266,43 @@ data class AgentListResponse(
 
     override fun results() = agents
 }
+
+@Serializable
+data class SaveLifeCyclePolicyRequest(
+    val agentLifeCyclePolicies: List<AgentLifeCyclePolicyRequest>,
+) : RioRequest
+
+@Serializable
+data class AgentLifeCyclePolicyRequest(
+    val agentName: String,
+    val lifeCycleUuid: String,
+    val restorePriority: Int,
+    val peakHours: List<DailyPeakHoursRequest>,
+) : RioRequest
+
+@Serializable
+data class DailyPeakHoursRequest(
+    val startMinuteOfDay: Int,
+    val endMinuteOfDay: Int,
+) : RioRequest
+
+@Serializable
+data class LifeCyclePolicyResponse(
+    val broker: String,
+    val agentLifeCycles: List<AgentLifeCyclePolicyResponse>,
+) : RioResponse()
+
+@Serializable
+data class AgentLifeCyclePolicyResponse(
+    val agentName: String,
+    val lifeCycleUuid: String,
+    val restorePriority: Int,
+    val peakHours: List<DailyPeakHoursResponse>? = null,
+) : RioResponse()
+
+@Serializable
+data class DailyPeakHoursResponse(
+    val startMinuteOfDay: Int,
+    val endMinuteOfDay: Int,
+) : RioResponse()
+

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -390,6 +390,24 @@ class RioClient(
     suspend fun headLifeCyclePolicy(brokerName: String): Boolean =
         client.myHead("$api/brokers/$brokerName/policy")
 
+    suspend fun createLifeCycle(lifeCycleRequest: LifeCycleRequest): LifeCycleResponse =
+        client.myPost("$api/lifecycle", lifeCycleRequest)
+
+    suspend fun updateLifeCycle(lifecycleId: String, lifeCycleRequest: LifeCycleRequest): LifeCycleResponse =
+        client.myPut("$api/lifecycle/$lifecycleId", lifeCycleRequest)
+
+    suspend fun deleteLifeCycle(lifecycleId: String): EmptyResponse =
+        client.myDelete("$api/lifecycle/$lifecycleId")
+
+    suspend fun getLifeCycle(lifecycleId: String): LifeCycleResponse =
+            client.myGet("$api/lifecycle/$lifecycleId")
+
+    suspend fun headLifeCycle(lifecycleId: String): Boolean =
+        client.myHead("$api/lifecycle/$lifecycleId")
+
+    suspend fun listLifeCycle(): ListLifeCycleResponse =
+        client.myGet("$api/lifecycle")
+
     /**
      * Object
      */

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -374,6 +374,22 @@ class RioClient(
         return client.myPut("$api/brokers/$brokerName/agents/$agentName", paramMap = paramMap)
     }
 
+    // Lifecycle
+    suspend fun saveLifeCyclePolicy(
+        brokerName: String,
+        saveLifeCyclePolicyRequest: SaveLifeCyclePolicyRequest
+    ): LifeCyclePolicyResponse =
+        client.myPost("$api/brokers/$brokerName/policy", saveLifeCyclePolicyRequest)
+
+    suspend fun getLifeCyclePolicy(brokerName: String): LifeCyclePolicyResponse =
+        client.myGet("$api/brokers/$brokerName/policy")
+
+    suspend fun deleteLifeCyclePolicy(brokerName: String): EmptyResponse =
+        client.myDelete("$api/brokers/$brokerName/policy")
+
+    suspend fun headLifeCyclePolicy(brokerName: String): Boolean =
+        client.myHead("$api/brokers/$brokerName/policy")
+
     /**
      * Object
      */

--- a/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/RioClient.kt
@@ -377,36 +377,29 @@ class RioClient(
     // Lifecycle
     suspend fun saveLifeCyclePolicy(
         brokerName: String,
-        saveLifeCyclePolicyRequest: SaveLifeCyclePolicyRequest
-    ): LifeCyclePolicyResponse =
-        client.myPost("$api/brokers/$brokerName/policy", saveLifeCyclePolicyRequest)
+        saveLifeCyclePolicyRequest: SaveLifeCyclePolicyRequest,
+    ): LifeCyclePolicyResponse = client.myPost("$api/brokers/$brokerName/policy", saveLifeCyclePolicyRequest)
 
-    suspend fun getLifeCyclePolicy(brokerName: String): LifeCyclePolicyResponse =
-        client.myGet("$api/brokers/$brokerName/policy")
+    suspend fun getLifeCyclePolicy(brokerName: String): LifeCyclePolicyResponse = client.myGet("$api/brokers/$brokerName/policy")
 
-    suspend fun deleteLifeCyclePolicy(brokerName: String): EmptyResponse =
-        client.myDelete("$api/brokers/$brokerName/policy")
+    suspend fun deleteLifeCyclePolicy(brokerName: String): EmptyResponse = client.myDelete("$api/brokers/$brokerName/policy")
 
-    suspend fun headLifeCyclePolicy(brokerName: String): Boolean =
-        client.myHead("$api/brokers/$brokerName/policy")
+    suspend fun headLifeCyclePolicy(brokerName: String): Boolean = client.myHead("$api/brokers/$brokerName/policy")
 
-    suspend fun createLifeCycle(lifeCycleRequest: LifeCycleRequest): LifeCycleResponse =
-        client.myPost("$api/lifecycle", lifeCycleRequest)
+    suspend fun createLifeCycle(lifeCycleRequest: LifeCycleRequest): LifeCycleResponse = client.myPost("$api/lifecycle", lifeCycleRequest)
 
-    suspend fun updateLifeCycle(lifecycleId: String, lifeCycleRequest: LifeCycleRequest): LifeCycleResponse =
-        client.myPut("$api/lifecycle/$lifecycleId", lifeCycleRequest)
+    suspend fun updateLifeCycle(
+        lifecycleId: String,
+        lifeCycleRequest: LifeCycleRequest,
+    ): LifeCycleResponse = client.myPut("$api/lifecycle/$lifecycleId", lifeCycleRequest)
 
-    suspend fun deleteLifeCycle(lifecycleId: String): EmptyResponse =
-        client.myDelete("$api/lifecycle/$lifecycleId")
+    suspend fun deleteLifeCycle(lifecycleId: String): EmptyResponse = client.myDelete("$api/lifecycle/$lifecycleId")
 
-    suspend fun getLifeCycle(lifecycleId: String): LifeCycleResponse =
-            client.myGet("$api/lifecycle/$lifecycleId")
+    suspend fun getLifeCycle(lifecycleId: String): LifeCycleResponse = client.myGet("$api/lifecycle/$lifecycleId")
 
-    suspend fun headLifeCycle(lifecycleId: String): Boolean =
-        client.myHead("$api/lifecycle/$lifecycleId")
+    suspend fun headLifeCycle(lifecycleId: String): Boolean = client.myHead("$api/lifecycle/$lifecycleId")
 
-    suspend fun listLifeCycle(): ListLifeCycleResponse =
-        client.myGet("$api/lifecycle")
+    suspend fun listLifeCycle(): ListLifeCycleResponse = client.myGet("$api/lifecycle")
 
     /**
      * Object
@@ -980,8 +973,8 @@ class RioClient(
     private suspend inline fun HttpClient.myPatch(
         url: String,
         request: RioRequest?,
-    ): Boolean {
-        return try {
+    ): Boolean =
+        try {
             patch(url) {
                 contentType(jsonContentType)
                 request?.let { setBody(encodeRioRequest(it)) }
@@ -997,7 +990,6 @@ class RioClient(
         } catch (t: Throwable) {
             throw RioHttpException(HttpMethod.Patch, url, t)
         }
-    }
 
     private suspend inline fun <reified T : RioResponse> HttpClient.myPost(
         url: String,

--- a/src/test/kotlin/com/spectralogic/rioclient/RioClientTest.kt
+++ b/src/test/kotlin/com/spectralogic/rioclient/RioClientTest.kt
@@ -2002,10 +2002,11 @@ class RioClientTest {
             ),
         )
 
-        val lifeCycleId = rioClient.createLifeCycle(LifeCycleRequest("test-$uuid", -1, -1)).let { resp ->
-            assertThat(resp.statusCode).isEqualTo(HttpStatusCode.Created)
-            resp.uuid
-        }
+        val lifeCycleId =
+            rioClient.createLifeCycle(LifeCycleRequest("test-$uuid", -1, -1)).let { resp ->
+                assertThat(resp.statusCode).isEqualTo(HttpStatusCode.Created)
+                resp.uuid
+            }
 
         val goodRequest =
             AgentLifeCyclePolicyRequest(


### PR DESCRIPTION
 Need life cycle APIs in order to complete.

These base tests are only useful while adding to the RioClient library.  They will be duplicated and expanded as tests in the RioBroker code base under:  

`devintegration/src/test/kotlin/com/spectralogic/escapepod/clienttest/`