### PR TITLE
Replace Jetty with CIO to avoid ALPN error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.spectralogic.rio"
-version = "3.2.2"
+version = "3.2.4"
 
 dependencies {
     implementation(platform(libs.kotlinBom))
@@ -23,7 +23,7 @@ dependencies {
 
     implementation(libs.kotlinxCoroutinesCore)
     implementation(libs.ktorClientCore)
-    implementation(libs.ktorClientJetty)
+    implementation(libs.ktorClientCIO)
     implementation(libs.ktorClientJson)
     implementation(libs.ktorClientLogging)
     implementation(libs.ktorClientContentNegotiation)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ dependencyResolutionManagement {
             library("kotlinxCoroutinesCore", "org.jetbrains.kotlinx", "kotlinx-coroutines-core").versionRef("kotlinxCoroutines")
             library("ktorBom", "io.ktor", "ktor-bom").versionRef("ktor")
             library("ktorClientAuth", "io.ktor", "ktor-client-auth").withoutVersion()
-            library("ktorClientJetty", "io.ktor", "ktor-client-jetty").withoutVersion()
+            library("ktorClientCIO", "io.ktor", "ktor-client-cio").withoutVersion()
             library("ktorClientContentNegotiation", "io.ktor", "ktor-client-content-negotiation").withoutVersion()
             library("ktorClientCore", "io.ktor", "ktor-client-core").withoutVersion()
             library("ktorClientJson", "io.ktor", "ktor-client-json").withoutVersion()

--- a/src/main/kotlin/com/spectralogic/rioclient/HttpClientFactory.kt
+++ b/src/main/kotlin/com/spectralogic/rioclient/HttpClientFactory.kt
@@ -2,7 +2,7 @@ package com.spectralogic.rioclient
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.jetty.Jetty
+import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
@@ -17,7 +17,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
-import org.eclipse.jetty.util.ssl.SslContextFactory
+import javax.net.ssl.X509TrustManager
 
 object HttpClientFactory {
     fun createHttpClient(
@@ -26,10 +26,15 @@ object HttpClientFactory {
         verbose: Boolean,
         requestTimeout: Long,
     ): HttpClient =
-        HttpClient(Jetty) {
+        HttpClient(CIO) {
             engine {
-                sslContextFactory = SslContextFactory.Client(true)
-                clientCacheSize = 12
+                https {
+                    trustManager = object : X509TrustManager {
+                        override fun checkClientTrusted(p0: Array<out java.security.cert.X509Certificate>?, p1: String?) {}
+                        override fun checkServerTrusted(p0: Array<out java.security.cert.X509Certificate>?, p1: String?) {}
+                        override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate>? = arrayOf()
+                    }
+                }
             }
             install(HttpTimeout) {
                 requestTimeoutMillis = requestTimeout


### PR DESCRIPTION
I've tested this locally with maven local and this fixes our devInt tests that get the Jetty ALPN error. I'll put up a Rio PR as soon as this is merged and I can publish.